### PR TITLE
Initial planning docs and wireframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# LostDecks
-Just a test
+# Lost Tales Marketplace
+
+This repository contains an early prototype for a web application that
+facilitates trading of Brandon Sanderson "Lost Tales" collectible story
+cards. The project is still in the planning phase, but a simple
+wireframe has been created to outline navigation and page structure.
+
+## Getting Started
+
+The `frontend` directory contains a static HTML prototype built with
+React (loaded via CDN). Open `frontend/index.html` in a web browser to
+explore the wireframe. Internet access is required because the page
+loads React and React Router from public CDNs.
+
+See `docs/plan.md` for a high-level plan of the pages and features
+considered for the minimum viable product.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,0 +1,39 @@
+# Lost Tales Marketplace Plan
+
+This document outlines a very early roadmap for a simple web application that allows
+users to trade Brandon Sanderson "Lost Tales" collectible story cards.
+
+## Goals
+
+- Minimum viable product (MVP)
+  - View a list of available cards
+  - Market makers can create an offer to sell a card or place a bounty
+  - Market takers can accept an existing offer
+  - Focus on a straightforward interface with minimal friction
+
+## Page Overview
+
+| Page             | Description                                                  |
+|------------------|--------------------------------------------------------------|
+| **Home**         | Landing page with brief introduction and navigation links.   |
+| **Cards**        | Browse all cards and see current bids/asks.                  |
+| **Market Maker** | Form to create an offer to sell a card or request a bounty.  |
+| **Market Taker** | View existing offers and accept one.                         |
+| **Not Found**    | Fallback page for unknown routes.                            |
+
+### Future Ideas
+
+- User accounts with login and portfolio tracking
+- Search and filtering of cards
+- Transaction history
+- Admin features for curating cards and offers
+
+## Wireframe Prototype
+
+The `frontend` directory contains a very simple wireframe built with
+React (via CDN). It demonstrates basic navigation between the pages
+listed above using React Router. The wireframe is purely for planning
+purposes and does not persist any data.
+
+To preview the prototype, open `frontend/index.html` in a browser with
+internet access.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lost Tales Marketplace Wireframe</title>
+  <link rel="stylesheet" href="styles.css">
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script type="text/babel">
+    const { BrowserRouter, Routes, Route, Link } = ReactRouterDOM;
+
+    function Home() {
+      return (
+        <div>
+          <h1>Lost Tales Marketplace</h1>
+          <p>Welcome to the trading card marketplace.</p>
+        </div>
+      );
+    }
+
+    function Cards() {
+      return (
+        <div>
+          <h2>Cards</h2>
+          <p>View available cards and current offers.</p>
+        </div>
+      );
+    }
+
+    function MarketMaker() {
+      return (
+        <div>
+          <h2>Market Maker</h2>
+          <p>Create an offer to sell or request a card.</p>
+        </div>
+      );
+    }
+
+    function MarketTaker() {
+      return (
+        <div>
+          <h2>Market Taker</h2>
+          <p>Accept an existing offer.</p>
+        </div>
+      );
+    }
+
+    function NotFound() {
+      return <h2>Page not found</h2>;
+    }
+
+    function App() {
+      return (
+        <BrowserRouter>
+          <nav>
+            <Link to="/">Home</Link> |{' '}
+            <Link to="/cards">Cards</Link> |{' '}
+            <Link to="/maker">Market Maker</Link> |{' '}
+            <Link to="/taker">Market Taker</Link>
+          </nav>
+          <hr />
+          <Routes>
+            <Route path="/" element={<Home />} />
+            <Route path="/cards" element={<Cards />} />
+            <Route path="/maker" element={<MarketMaker />} />
+            <Route path="/taker" element={<MarketTaker />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,29 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+nav {
+  background: #333;
+  color: #fff;
+  padding: 0.5em;
+}
+
+nav a {
+  color: #fff;
+  margin-right: 1em;
+  text-decoration: none;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}
+
+h1, h2 {
+  margin: 0.5em 0;
+}
+
+#root {
+  padding: 1em;
+}


### PR DESCRIPTION
## Summary
- outline initial project roadmap in `docs/plan.md`
- add a README describing the prototype
- include simple React wireframe using CDN dependencies

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687dc337ca508332bf46c88e97b4d723