### PR TITLE
Fix frontend dev setup docs and add .env.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,31 @@ wireframe has been created to outline navigation and page structure.
 
 ## Getting Started
 
-The `frontend` directory contains a static HTML prototype built with
-React (loaded via CDN). Open `frontend/index.html` in a web browser to
-explore the wireframe. Internet access is required because the page
-loads React and React Router from public CDNs.
+### Frontend (Vite + React)
 
-See `docs/plan.md` for a high-level plan of the pages and features
-considered for the minimum viable product.
+The `frontend` directory contains a Vite-powered React application.
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+#### Firebase configuration
+
+The frontend expects Firebase configuration via Vite environment variables.
+Copy `frontend/.env.example` to `frontend/.env` and fill in your Firebase
+project credentials:
+
+```bash
+cd frontend
+cp .env.example .env
+```
+
+> Note: The app can still render without Firebase configured, but auth-related
+> features will be unavailable.
+
+### Planning docs
+
+See `docs/plan.md` for a high-level plan of the pages and features considered
+for the minimum viable product.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,10 @@
+# Firebase (Vite)
+# Copy this file to .env and replace the placeholders with values from your Firebase project settings.
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_MEASUREMENT_ID=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -22,6 +22,16 @@ This Vite-powered React application implements the Lost Tales Marketplace experi
    cp .env.example .env
    ```
 
+   Required variables (see `src/lib/firebase.js`):
+
+   - `VITE_FIREBASE_API_KEY`
+   - `VITE_FIREBASE_AUTH_DOMAIN`
+   - `VITE_FIREBASE_PROJECT_ID`
+   - `VITE_FIREBASE_STORAGE_BUCKET`
+   - `VITE_FIREBASE_MESSAGING_SENDER_ID`
+   - `VITE_FIREBASE_APP_ID`
+   - `VITE_FIREBASE_MEASUREMENT_ID`
+
 3. Start the development server:
 
    ```bash


### PR DESCRIPTION
This repo's root README described the frontend as a static CDN-loaded prototype, but the current frontend is a Vite + React app.\n\nChanges:\n- Update root README with correct dev commands (cd frontend, npm install, npm run dev)\n- Document Firebase env var setup\n- Add frontend/.env.example with VITE_FIREBASE_* placeholders\n- Clarify required env vars in frontend/README\n\nNo secrets included; the .env.example contains only empty placeholders.