### PR TITLE
Local Firebase emulators for multi-user testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*-debug.log
+firebase-debug.log
+firestore-debug.log
+
+# Local emulator env (Vite mode=emulator)
+frontend/.env.emulator.local
 
 .vs/slnx.sqlite

--- a/README.md
+++ b/README.md
@@ -9,29 +9,35 @@ wireframe has been created to outline navigation and page structure.
 
 ### Frontend (Vite + React)
 
-The `frontend` directory contains a Vite-powered React application.
+The app lives in `frontend/`.
 
 ```bash
 cd frontend
 npm install
-npm run dev
+cp .env.example .env.local
+# fill in VITE_FIREBASE_* values
+npm run dev -- --host 127.0.0.1 --port 5174
 ```
 
-#### Firebase configuration
+### Firebase (Auth + Firestore)
 
-The frontend expects Firebase configuration via Vite environment variables.
-Copy `frontend/.env.example` to `frontend/.env` and fill in your Firebase
-project credentials:
+This repo includes Firestore security rules in `firestore.rules` and Firebase Emulator Suite configuration in `firebase.json`.
+
+For local multi-user testing (recommended), run the emulators and point the frontend at them:
 
 ```bash
+# terminal 1
+cd ..
+firebase emulators:start --only auth,firestore
+
+# terminal 2
 cd frontend
-cp .env.example .env
+npm run dev -- --mode emulator --host 127.0.0.1 --port 5174
 ```
 
-> Note: The app can still render without Firebase configured, but auth-related
-> features will be unavailable.
+Emulator UI:
+- http://127.0.0.1:4000/
 
-### Planning docs
+See `frontend/README.md` for details.
 
-See `docs/plan.md` for a high-level plan of the pages and features considered
-for the minimum viable product.
+See `docs/plan.md` for a high-level plan of the pages and features considered for the minimum viable product.

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,18 @@
 {
   "firestore": {
     "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "auth": {
+      "port": 9099
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
   }
 }

--- a/frontend/.env.emulator.example
+++ b/frontend/.env.emulator.example
@@ -1,0 +1,8 @@
+# Copy to .env.local (or .env.emulator if you prefer) to run the frontend against Firebase Emulators.
+# Note: Vite only auto-loads .env, .env.local, .env.[mode], .env.[mode].local.
+# If you use .env.emulator, start Vite with: npm run dev -- --mode emulator
+
+VITE_USE_EMULATORS=true
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://127.0.0.1:9099
+VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1
+VITE_FIRESTORE_EMULATOR_PORT=8080

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,6 @@
-# Firebase (Vite)
-# Copy this file to .env and replace the placeholders with values from your Firebase project settings.
+# Copy to .env.local and fill in values from Firebase Console
 
+# Firebase Web config (from Firebase Console)
 VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=
@@ -8,3 +8,11 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
+
+# --- Local Emulator Suite (optional) ---
+# Set true to force Auth + Firestore to use local emulators.
+VITE_USE_EMULATORS=false
+# Defaults match Firebase Emulator Suite defaults.
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://127.0.0.1:9099
+VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1
+VITE_FIRESTORE_EMULATOR_PORT=8080

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,10 +16,10 @@ This Vite-powered React application implements the Lost Tales Marketplace experi
    npm install
    ```
 
-2. Copy `.env.example` to `.env` and populate it with your Firebase project credentials:
+2. Copy `.env.example` to `.env.local` and populate it with your Firebase project credentials:
 
    ```bash
-   cp .env.example .env
+   cp .env.example .env.local
    ```
 
    Required variables (see `src/lib/firebase.js`):
@@ -35,8 +35,36 @@ This Vite-powered React application implements the Lost Tales Marketplace experi
 3. Start the development server:
 
    ```bash
-   npm run dev
+   npm run dev -- --host 127.0.0.1 --port 5174
    ```
+
+## Local multi-user testing (Firebase Emulator Suite)
+
+This project supports running against local Firebase emulators (Auth + Firestore). This is the recommended setup for testing multi-user flows like offers/acceptance.
+
+1. Start emulators from the repo root:
+
+   ```bash
+   cd ..
+   firebase emulators:start --only auth,firestore
+   ```
+
+2. Start the frontend in emulator mode:
+
+   ```bash
+   npm run dev -- --mode emulator --host 127.0.0.1 --port 5174
+   ```
+
+3. Create test users:
+
+- Use two browser profiles/contexts (regular + incognito) and sign up as different users.
+- Confirm users exist in Emulator UI: http://127.0.0.1:4000/auth
+
+### Emulator env vars
+
+Vite loads `.env.emulator.local` automatically when you run with `--mode emulator`.
+
+See `.env.emulator.example` for the values.
 
 ## Authentication Features
 

--- a/frontend/src/firebaseClient.js
+++ b/frontend/src/firebaseClient.js
@@ -1,0 +1,5 @@
+// Back-compat shim.
+// The project already uses src/lib/firebase.js as the canonical Firebase setup
+// (Auth + Firestore + providers). Prefer importing from that module.
+
+export * from './lib/firebase';

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -1,6 +1,13 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider, GithubAuthProvider, setPersistence, browserLocalPersistence } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  GithubAuthProvider,
+  setPersistence,
+  browserLocalPersistence,
+  connectAuthEmulator,
+} from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -25,6 +32,30 @@ if (!hasFirebaseConfig) {
 const app = hasFirebaseConfig ? (getApps().length ? getApp() : initializeApp(firebaseConfig)) : null;
 const auth = app ? getAuth(app) : null;
 const db = app ? getFirestore(app) : null;
+
+// --- Local Emulator support (Auth + Firestore) ---
+// Enable via VITE_USE_EMULATORS=true in .env.local (or a dedicated .env.emulator).
+// IMPORTANT: the emulator connection must be configured BEFORE your app makes any auth/db calls.
+const useEmulators = String(import.meta.env.VITE_USE_EMULATORS || '').toLowerCase() === 'true';
+
+if (useEmulators && auth && db) {
+  const authUrl = import.meta.env.VITE_FIREBASE_AUTH_EMULATOR_URL || 'http://127.0.0.1:9099';
+  const fsHost = import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+  const fsPort = Number(import.meta.env.VITE_FIRESTORE_EMULATOR_PORT || 8080);
+
+  try {
+    connectAuthEmulator(auth, authUrl, { disableWarnings: true });
+  } catch (err) {
+    // Ignore "already configured" errors during HMR.
+    console.debug('Auth emulator connection skipped', err);
+  }
+
+  try {
+    connectFirestoreEmulator(db, fsHost, fsPort);
+  } catch (err) {
+    console.debug('Firestore emulator connection skipped', err);
+  }
+}
 
 if (auth) {
   setPersistence(auth, browserLocalPersistence).catch((error) => {


### PR DESCRIPTION
This PR adds a local testing workflow for multi-user interactions using the Firebase Emulator Suite.\n\nChanges:\n- firebase.json: configure Auth + Firestore emulators (ports 9099/8080) and Emulator UI (4000)\n- frontend/src/lib/firebase.js: optional emulator wiring via VITE_USE_EMULATORS + VITE_* emulator vars\n- frontend/src/firebaseClient.js: back-compat re-export shim\n- frontend/.env.example + frontend/.env.emulator.example: documented env vars\n- README updates: local dev + emulator instructions\n- .gitignore: ignore emulator debug logs and .env.emulator.local\n\nHow to test:\n1) firebase emulators:start --only auth,firestore\n2) npm run dev -- --mode emulator\n3) Create two accounts in two browser contexts (regular + incognito)