### PR TITLE
Market: cancel listings + create trade records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,11 @@ Thumbs.db
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+*-debug.log
+firebase-debug.log
+firestore-debug.log
+
+# Local emulator env (Vite mode=emulator)
+frontend/.env.emulator.local
 
 .vs/slnx.sqlite

--- a/README.md
+++ b/README.md
@@ -9,29 +9,35 @@ wireframe has been created to outline navigation and page structure.
 
 ### Frontend (Vite + React)
 
-The `frontend` directory contains a Vite-powered React application.
+The app lives in `frontend/`.
 
 ```bash
 cd frontend
 npm install
-npm run dev
+cp .env.example .env.local
+# fill in VITE_FIREBASE_* values
+npm run dev -- --host 127.0.0.1 --port 5174
 ```
 
-#### Firebase configuration
+### Firebase (Auth + Firestore)
 
-The frontend expects Firebase configuration via Vite environment variables.
-Copy `frontend/.env.example` to `frontend/.env` and fill in your Firebase
-project credentials:
+This repo includes Firestore security rules in `firestore.rules` and Firebase Emulator Suite configuration in `firebase.json`.
+
+For local multi-user testing (recommended), run the emulators and point the frontend at them:
 
 ```bash
+# terminal 1
+cd ..
+firebase emulators:start --only auth,firestore
+
+# terminal 2
 cd frontend
-cp .env.example .env
+npm run dev -- --mode emulator --host 127.0.0.1 --port 5174
 ```
 
-> Note: The app can still render without Firebase configured, but auth-related
-> features will be unavailable.
+Emulator UI:
+- http://127.0.0.1:4000/
 
-### Planning docs
+See `frontend/README.md` for details.
 
-See `docs/plan.md` for a high-level plan of the pages and features considered
-for the minimum viable product.
+See `docs/plan.md` for a high-level plan of the pages and features considered for the minimum viable product.

--- a/firebase.json
+++ b/firebase.json
@@ -1,5 +1,18 @@
 {
   "firestore": {
     "rules": "firestore.rules"
+  },
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "auth": {
+      "port": 9099
+    },
+    "ui": {
+      "enabled": true,
+      "port": 4000
+    },
+    "singleProjectMode": true
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,24 +1,65 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
+    function signedIn() {
+      return request.auth != null;
+    }
+
     // Collections collection - user's card collection entries
     match /collections/{entryId} {
       // Users can read their own collection entries
-      allow read: if request.auth != null && request.auth.uid == resource.data.ownerUid;
-      
+      allow read: if signedIn() && request.auth.uid == resource.data.ownerUid;
+
       // Users can create entries if authenticated and setting their own UID
-      allow create: if request.auth != null 
-        && request.auth.uid == request.resource.data.ownerUid;
-      
-      // Users can update their own entries
-      allow update: if request.auth != null 
+      allow create: if signedIn() && request.auth.uid == request.resource.data.ownerUid;
+
+      // Users can update their own entries (and can't change ownerUid)
+      allow update: if signedIn()
         && request.auth.uid == resource.data.ownerUid
-        && request.auth.uid == request.resource.data.ownerUid; // Prevent UID changes
-      
+        && request.auth.uid == request.resource.data.ownerUid;
+
       // Users can delete their own entries
-      allow delete: if request.auth != null && request.auth.uid == resource.data.ownerUid;
+      allow delete: if signedIn() && request.auth.uid == resource.data.ownerUid;
     }
-    
+
+    // Market listings (public read; auth write)
+    match /listings/{listingId} {
+      allow read: if true;
+
+      // Create OPEN listings only for yourself.
+      allow create: if signedIn()
+        && request.resource.data.status == 'OPEN'
+        && (request.resource.data.type == 'BID' || request.resource.data.type == 'ASK')
+        && request.resource.data.currency == 'USD'
+        && request.resource.data.quantity == 1
+        && request.resource.data.createdByUid == request.auth.uid
+        && request.resource.data.priceCents is int
+        && request.resource.data.priceCents > 0
+        && request.resource.data.cardId is string
+        && request.resource.data.cardId.size() > 0;
+
+      // Allow the creator to cancel their own OPEN listing.
+      allow update: if signedIn()
+        && resource.data.createdByUid == request.auth.uid
+        && resource.data.status == 'OPEN'
+        && request.resource.data.status == 'CANCELLED'
+        && request.resource.data.createdByUid == resource.data.createdByUid
+        && request.resource.data.type == resource.data.type
+        && request.resource.data.cardId == resource.data.cardId
+        && request.resource.data.priceCents == resource.data.priceCents
+        && request.resource.data.currency == resource.data.currency
+        && request.resource.data.quantity == resource.data.quantity;
+
+      // Allow delete only for creator (optional; not used yet)
+      allow delete: if signedIn() && resource.data.createdByUid == request.auth.uid;
+    }
+
+    // Trades (not enabled yet; accept flow ships next)
+    match /trades/{tradeId} {
+      allow read: if signedIn() && (request.auth.uid == resource.data.buyerUid || request.auth.uid == resource.data.sellerUid);
+      allow create, update, delete: if false;
+    }
+
     // Deny all other collections by default
     match /{document=**} {
       allow read, write: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -72,10 +72,24 @@ service cloud.firestore {
       allow delete: if signedIn() && resource.data.createdByUid == request.auth.uid;
     }
 
-    // Trades (not enabled yet; accept flow ships next)
+    // Trades (created when a listing is accepted)
     match /trades/{tradeId} {
       allow read: if signedIn() && (request.auth.uid == resource.data.buyerUid || request.auth.uid == resource.data.sellerUid);
-      allow create, update, delete: if false;
+
+      // MVP: allow buyer or seller to create a trade record.
+      // NOTE: This does not strictly enforce atomic coupling with the listing acceptance.
+      allow create: if signedIn()
+        && (request.auth.uid == request.resource.data.buyerUid || request.auth.uid == request.resource.data.sellerUid)
+        && request.resource.data.status == 'PENDING'
+        && request.resource.data.listingId is string
+        && request.resource.data.cardId is string
+        && (request.resource.data.type == 'BID' || request.resource.data.type == 'ASK')
+        && request.resource.data.currency == 'USD'
+        && request.resource.data.quantity == 1
+        && request.resource.data.priceCents is int
+        && request.resource.data.priceCents > 0;
+
+      allow update, delete: if false;
     }
 
     // Deny all other collections by default

--- a/firestore.rules
+++ b/firestore.rules
@@ -38,17 +38,35 @@ service cloud.firestore {
         && request.resource.data.cardId is string
         && request.resource.data.cardId.size() > 0;
 
-      // Allow the creator to cancel their own OPEN listing.
-      allow update: if signedIn()
-        && resource.data.createdByUid == request.auth.uid
-        && resource.data.status == 'OPEN'
-        && request.resource.data.status == 'CANCELLED'
-        && request.resource.data.createdByUid == resource.data.createdByUid
-        && request.resource.data.type == resource.data.type
-        && request.resource.data.cardId == resource.data.cardId
-        && request.resource.data.priceCents == resource.data.priceCents
-        && request.resource.data.currency == resource.data.currency
-        && request.resource.data.quantity == resource.data.quantity;
+      // Allow updates for: cancel (creator) or accept (someone else)
+      allow update: if signedIn() && (
+        // Cancel: creator can cancel their own OPEN listing.
+        (
+          resource.data.createdByUid == request.auth.uid
+          && resource.data.status == 'OPEN'
+          && request.resource.data.status == 'CANCELLED'
+          && request.resource.data.createdByUid == resource.data.createdByUid
+          && request.resource.data.type == resource.data.type
+          && request.resource.data.cardId == resource.data.cardId
+          && request.resource.data.priceCents == resource.data.priceCents
+          && request.resource.data.currency == resource.data.currency
+          && request.resource.data.quantity == resource.data.quantity
+        )
+        ||
+        // Accept: a non-creator can accept an OPEN listing.
+        (
+          resource.data.createdByUid != request.auth.uid
+          && resource.data.status == 'OPEN'
+          && request.resource.data.status == 'ACCEPTED'
+          && request.resource.data.createdByUid == resource.data.createdByUid
+          && request.resource.data.type == resource.data.type
+          && request.resource.data.cardId == resource.data.cardId
+          && request.resource.data.priceCents == resource.data.priceCents
+          && request.resource.data.currency == resource.data.currency
+          && request.resource.data.quantity == resource.data.quantity
+          && request.resource.data.acceptedByUid == request.auth.uid
+        )
+      );
 
       // Allow delete only for creator (optional; not used yet)
       allow delete: if signedIn() && resource.data.createdByUid == request.auth.uid;

--- a/frontend/.env.emulator.example
+++ b/frontend/.env.emulator.example
@@ -1,0 +1,8 @@
+# Copy to .env.local (or .env.emulator if you prefer) to run the frontend against Firebase Emulators.
+# Note: Vite only auto-loads .env, .env.local, .env.[mode], .env.[mode].local.
+# If you use .env.emulator, start Vite with: npm run dev -- --mode emulator
+
+VITE_USE_EMULATORS=true
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://127.0.0.1:9099
+VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1
+VITE_FIRESTORE_EMULATOR_PORT=8080

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,6 @@
-# Firebase (Vite)
-# Copy this file to .env and replace the placeholders with values from your Firebase project settings.
+# Copy to .env.local and fill in values from Firebase Console
 
+# Firebase Web config (from Firebase Console)
 VITE_FIREBASE_API_KEY=
 VITE_FIREBASE_AUTH_DOMAIN=
 VITE_FIREBASE_PROJECT_ID=
@@ -8,3 +8,11 @@ VITE_FIREBASE_STORAGE_BUCKET=
 VITE_FIREBASE_MESSAGING_SENDER_ID=
 VITE_FIREBASE_APP_ID=
 VITE_FIREBASE_MEASUREMENT_ID=
+
+# --- Local Emulator Suite (optional) ---
+# Set true to force Auth + Firestore to use local emulators.
+VITE_USE_EMULATORS=false
+# Defaults match Firebase Emulator Suite defaults.
+VITE_FIREBASE_AUTH_EMULATOR_URL=http://127.0.0.1:9099
+VITE_FIRESTORE_EMULATOR_HOST=127.0.0.1
+VITE_FIRESTORE_EMULATOR_PORT=8080

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,10 +16,10 @@ This Vite-powered React application implements the Lost Tales Marketplace experi
    npm install
    ```
 
-2. Copy `.env.example` to `.env` and populate it with your Firebase project credentials:
+2. Copy `.env.example` to `.env.local` and populate it with your Firebase project credentials:
 
    ```bash
-   cp .env.example .env
+   cp .env.example .env.local
    ```
 
    Required variables (see `src/lib/firebase.js`):
@@ -35,8 +35,36 @@ This Vite-powered React application implements the Lost Tales Marketplace experi
 3. Start the development server:
 
    ```bash
-   npm run dev
+   npm run dev -- --host 127.0.0.1 --port 5174
    ```
+
+## Local multi-user testing (Firebase Emulator Suite)
+
+This project supports running against local Firebase emulators (Auth + Firestore). This is the recommended setup for testing multi-user flows like offers/acceptance.
+
+1. Start emulators from the repo root:
+
+   ```bash
+   cd ..
+   firebase emulators:start --only auth,firestore
+   ```
+
+2. Start the frontend in emulator mode:
+
+   ```bash
+   npm run dev -- --mode emulator --host 127.0.0.1 --port 5174
+   ```
+
+3. Create test users:
+
+- Use two browser profiles/contexts (regular + incognito) and sign up as different users.
+- Confirm users exist in Emulator UI: http://127.0.0.1:4000/auth
+
+### Emulator env vars
+
+Vite loads `.env.emulator.local` automatically when you run with `--mode emulator`.
+
+See `.env.emulator.example` for the values.
 
 ## Authentication Features
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import Login from './pages/Auth/Login';
 import Register from './pages/Auth/Register';
 import ForgotPassword from './pages/Auth/ForgotPassword';
 import CollectionPage from './pages/Collection';
-import OffersPage from './pages/Offers';
+import MarketPage from './pages/Market';
 import AccountPage from './pages/Account';
 import { useAuth } from './contexts/AuthContext';
 import { useAuthModal } from './contexts/AuthModalContext.jsx';
@@ -31,7 +31,7 @@ function App() {
           <Link to="/">Home</Link>
           <Link to="/cards">Cards</Link>
           <Link to="/collections">Collection</Link>
-          <Link to="/offers">Offers</Link>
+          <Link to="/market">Market</Link>
           <Link to="/account">Account</Link>
         </div>
         <div className="main-nav__auth">
@@ -61,7 +61,7 @@ function App() {
         <Route path="/cards/:cardId" element={<CardDetail />} />
         <Route path="/cards/:cardId/:skuId" element={<CardDetail />} />
         <Route path="/collections" element={<CollectionPage />} />
-        <Route path="/offers" element={<OffersPage />} />
+        <Route path="/market" element={<MarketPage />} />
         <Route path="/account" element={<AccountPage />} />
         <Route path="/auth/login" element={<Login />} />
         <Route path="/auth/register" element={<Register />} />

--- a/frontend/src/firebaseClient.js
+++ b/frontend/src/firebaseClient.js
@@ -1,0 +1,5 @@
+// Back-compat shim.
+// The project already uses src/lib/firebase.js as the canonical Firebase setup
+// (Auth + Firestore + providers). Prefer importing from that module.
+
+export * from './lib/firebase';

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -1,6 +1,13 @@
 import { initializeApp, getApps, getApp } from 'firebase/app';
-import { getAuth, GoogleAuthProvider, GithubAuthProvider, setPersistence, browserLocalPersistence } from 'firebase/auth';
-import { getFirestore } from 'firebase/firestore';
+import {
+  getAuth,
+  GoogleAuthProvider,
+  GithubAuthProvider,
+  setPersistence,
+  browserLocalPersistence,
+  connectAuthEmulator,
+} from 'firebase/auth';
+import { getFirestore, connectFirestoreEmulator } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
@@ -21,6 +28,30 @@ if (Object.values(firebaseConfig).some((value) => typeof value === 'undefined'))
 const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
+
+// --- Local Emulator support (Auth + Firestore) ---
+// Enable via VITE_USE_EMULATORS=true in .env.local (or a dedicated .env.emulator).
+// IMPORTANT: the emulator connection must be configured BEFORE your app makes any auth/db calls.
+const useEmulators = String(import.meta.env.VITE_USE_EMULATORS || '').toLowerCase() === 'true';
+
+if (useEmulators) {
+  const authUrl = import.meta.env.VITE_FIREBASE_AUTH_EMULATOR_URL || 'http://127.0.0.1:9099';
+  const fsHost = import.meta.env.VITE_FIRESTORE_EMULATOR_HOST || '127.0.0.1';
+  const fsPort = Number(import.meta.env.VITE_FIRESTORE_EMULATOR_PORT || 8080);
+
+  try {
+    connectAuthEmulator(auth, authUrl, { disableWarnings: true });
+  } catch (err) {
+    // Ignore "already configured" errors during HMR.
+    console.debug('Auth emulator connection skipped', err);
+  }
+
+  try {
+    connectFirestoreEmulator(db, fsHost, fsPort);
+  } catch (err) {
+    console.debug('Firestore emulator connection skipped', err);
+  }
+}
 
 setPersistence(auth, browserLocalPersistence).catch((error) => {
   console.error('Failed to set Firebase auth persistence', error);

--- a/frontend/src/lib/marketplace/listings.js
+++ b/frontend/src/lib/marketplace/listings.js
@@ -1,0 +1,52 @@
+import {
+  collection,
+  addDoc,
+  query,
+  where,
+  orderBy,
+  serverTimestamp,
+  onSnapshot,
+} from 'firebase/firestore';
+
+import { db } from '../../firebaseClient';
+
+export const LISTINGS_PATH = 'listings';
+
+export function subscribeOpenListings({ cardId } = {}, onNext, onError) {
+  const base = collection(db, LISTINGS_PATH);
+  const constraints = [where('status', '==', 'OPEN'), orderBy('createdAt', 'desc')];
+  if (cardId) {
+    constraints.unshift(where('cardId', '==', cardId));
+  }
+  const q = query(base, ...constraints);
+  return onSnapshot(q, onNext, onError);
+}
+
+export async function createListing({
+  type,
+  cardId,
+  priceCents,
+  currency = 'USD',
+  quantity = 1,
+  createdByUid,
+  createdByDisplayName,
+}) {
+  if (!type || !cardId || !createdByUid) {
+    throw new Error('Missing required listing fields');
+  }
+
+  const payload = {
+    type,
+    status: 'OPEN',
+    cardId,
+    priceCents,
+    currency,
+    quantity,
+    createdByUid,
+    createdByDisplayName: createdByDisplayName || 'Anonymous',
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  };
+
+  return addDoc(collection(db, LISTINGS_PATH), payload);
+}

--- a/frontend/src/lib/marketplace/trades.js
+++ b/frontend/src/lib/marketplace/trades.js
@@ -1,0 +1,37 @@
+import { collection, addDoc, serverTimestamp } from 'firebase/firestore';
+import { db } from '../../firebaseClient';
+
+export const TRADES_PATH = 'trades';
+
+export async function createTrade({
+  listingId,
+  cardId,
+  type,
+  priceCents,
+  currency = 'USD',
+  quantity = 1,
+  buyerUid,
+  buyerDisplayName,
+  sellerUid,
+  sellerDisplayName,
+}) {
+  if (!listingId || !cardId || !type) throw new Error('Missing trade fields');
+  if (!buyerUid || !sellerUid) throw new Error('Missing buyer/seller');
+
+  const payload = {
+    listingId,
+    cardId,
+    type,
+    priceCents,
+    currency,
+    quantity,
+    buyerUid,
+    buyerDisplayName: buyerDisplayName || 'Anonymous',
+    sellerUid,
+    sellerDisplayName: sellerDisplayName || 'Anonymous',
+    status: 'PENDING',
+    createdAt: serverTimestamp(),
+  };
+
+  return addDoc(collection(db, TRADES_PATH), payload);
+}

--- a/frontend/src/pages/CardDetail/CardDetail.css
+++ b/frontend/src/pages/CardDetail/CardDetail.css
@@ -145,29 +145,59 @@
   border-top: 1px solid rgba(116, 92, 190, 0.3);
 }
 
-.card-detail__offers-placeholder {
-  display: flex;
-  flex-direction: column;
+.create-listing {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(138, 43, 226, 0.25);
+  background: rgba(24, 18, 45, 0.6);
+}
+
+.create-listing__row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
   gap: 1rem;
-  align-items: flex-start;
 }
 
-.card-detail__offers-placeholder p {
-  margin: 0;
-  color: rgba(206, 193, 255, 0.7);
+.create-listing__label {
+  display: grid;
+  gap: 0.4rem;
+  color: rgba(206, 193, 255, 0.8);
+  font-size: 0.9rem;
 }
 
-.card-detail__offers-button {
+.create-listing select,
+.create-listing input {
+  border: 1px solid rgba(201, 182, 255, 0.35);
+  background: rgba(96, 66, 178, 0.25);
+  color: #ffffff;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+}
+
+.create-listing button {
+  justify-self: start;
   border: 1px solid rgba(201, 182, 255, 0.7);
   background: rgba(96, 66, 178, 0.45);
   color: #ffffff;
-  padding: 0.75rem 1.75rem;
+  padding: 0.65rem 1.25rem;
   border-radius: 999px;
   text-transform: uppercase;
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   letter-spacing: 0.12em;
+}
+
+.create-listing button:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.55;
+}
+
+@media (max-width: 520px) {
+  .create-listing__row {
+    grid-template-columns: 1fr;
+  }
 }
 
 .card-detail__error {

--- a/frontend/src/pages/CardDetail/components/CreateListingForm.jsx
+++ b/frontend/src/pages/CardDetail/components/CreateListingForm.jsx
@@ -1,0 +1,96 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../contexts/AuthContext';
+import { createListing } from '../../../lib/marketplace/listings';
+
+function dollarsToCents(value) {
+  const normalized = String(value || '').trim();
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+  return Math.round(parsed * 100);
+}
+
+export default function CreateListingForm({ cardId }) {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [type, setType] = useState('BID');
+  const [price, setPrice] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  const priceCents = useMemo(() => dollarsToCents(price), [price]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    if (!user) {
+      navigate('/auth/login', { state: { from: { pathname: `/cards/${cardId}` } } });
+      return;
+    }
+
+    if (!priceCents) {
+      setError('Enter a valid price.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await createListing({
+        type,
+        cardId,
+        priceCents,
+        currency: 'USD',
+        quantity: 1,
+        createdByUid: user.uid,
+        createdByDisplayName: user.displayName || user.email,
+      });
+      setPrice('');
+    } catch (err) {
+      console.error('Failed to create listing', err);
+      setError('Failed to create listing.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="create-listing">
+      <div className="create-listing__row">
+        <label className="create-listing__label">
+          Type
+          <select value={type} onChange={(e) => setType(e.target.value)} disabled={submitting}>
+            <option value="BID">Buy (Bid)</option>
+            <option value="ASK">Sell (Ask)</option>
+          </select>
+        </label>
+
+        <label className="create-listing__label">
+          Price (USD)
+          <input
+            type="number"
+            min="0"
+            step="0.01"
+            inputMode="decimal"
+            value={price}
+            onChange={(e) => setPrice(e.target.value)}
+            placeholder="10.00"
+            disabled={submitting}
+          />
+        </label>
+      </div>
+
+      {error && <p className="muted">{error}</p>}
+
+      <button type="submit" disabled={submitting}>
+        {user ? 'Create listing' : 'Sign in to create listing'}
+      </button>
+
+      <p className="muted" style={{ marginTop: '0.75rem' }}>
+        Quantity is fixed to 1 for now. We can add multi-quantity listings later.
+      </p>
+    </form>
+  );
+}

--- a/frontend/src/pages/CardDetail/index.jsx
+++ b/frontend/src/pages/CardDetail/index.jsx
@@ -8,6 +8,7 @@ import FinishPills from '../Cards/components/FinishPills';
 import BinderInfo from '../Cards/components/BinderInfo';
 import AddToCollectionButton from '../Cards/components/AddToCollectionButton';
 import { categoryLabels } from '../Cards/constants';
+import CreateListingForm from './components/CreateListingForm';
 import './CardDetail.css';
 
 function normalizeQuantity(entry) {
@@ -230,13 +231,11 @@ export default function CardDetail() {
         )}
 
         <section className="card-detail__offers">
-          <h2 className="card-detail__section-title">Make Offer</h2>
-          <div className="card-detail__offers-placeholder">
-            <p>Offer functionality coming soon</p>
-            <button type="button" className="card-detail__offers-button" disabled>
-              Make Offer
-            </button>
-          </div>
+          <h2 className="card-detail__section-title">Market</h2>
+          <p className="muted" style={{ marginTop: 0 }}>
+            Create a buy (bid) or sell (ask) listing for this card.
+          </p>
+          <CreateListingForm cardId={cardId} />
         </section>
       </div>
     </div>

--- a/frontend/src/pages/Market/Market.css
+++ b/frontend/src/pages/Market/Market.css
@@ -1,0 +1,59 @@
+.market-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.market-listing {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(138, 43, 226, 0.25);
+  background: rgba(24, 18, 45, 0.75);
+}
+
+.market-listing__main {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.market-listing__type {
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: rgba(206, 193, 255, 0.9);
+}
+
+.market-listing__price {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #ffffff;
+}
+
+.market-listing__meta {
+  color: rgba(206, 193, 255, 0.7);
+  font-size: 0.9rem;
+}
+
+.market-listing__actions button {
+  border: 1px solid rgba(201, 182, 255, 0.7);
+  background: rgba(96, 66, 178, 0.45);
+  color: #ffffff;
+  padding: 0.6rem 1.25rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+}
+
+.market-listing__actions button:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}

--- a/frontend/src/pages/Market/components/ListingRow.jsx
+++ b/frontend/src/pages/Market/components/ListingRow.jsx
@@ -7,7 +7,7 @@ function formatMoney(priceCents, currency = 'USD') {
   }
 }
 
-function ListingRow({ listing, onAccept, canAccept }) {
+function ListingRow({ listing, onAccept, canAccept, canCancel, onCancel }) {
   const label = listing.type === 'BID' ? 'Bid' : 'Ask';
 
   return (
@@ -22,9 +22,15 @@ function ListingRow({ listing, onAccept, canAccept }) {
         </div>
       </div>
       <div className="market-listing__actions">
-        <button type="button" onClick={() => onAccept?.(listing)} disabled={!canAccept}>
-          Accept
-        </button>
+        {canCancel ? (
+          <button type="button" onClick={() => onCancel?.(listing)}>
+            Cancel
+          </button>
+        ) : (
+          <button type="button" onClick={() => onAccept?.(listing)} disabled={!canAccept}>
+            Accept
+          </button>
+        )}
       </div>
     </li>
   );

--- a/frontend/src/pages/Market/components/ListingRow.jsx
+++ b/frontend/src/pages/Market/components/ListingRow.jsx
@@ -1,0 +1,33 @@
+function formatMoney(priceCents, currency = 'USD') {
+  const amount = typeof priceCents === 'number' ? priceCents / 100 : 0;
+  try {
+    return new Intl.NumberFormat(undefined, { style: 'currency', currency }).format(amount);
+  } catch {
+    return `${currency} ${(amount || 0).toFixed(2)}`;
+  }
+}
+
+function ListingRow({ listing, onAccept, canAccept }) {
+  const label = listing.type === 'BID' ? 'Bid' : 'Ask';
+
+  return (
+    <li className="market-listing">
+      <div className="market-listing__main">
+        <div className="market-listing__type">{label}</div>
+        <div className="market-listing__price">{formatMoney(listing.priceCents, listing.currency)}</div>
+        <div className="market-listing__meta">
+          <span className="muted">Card:</span> {listing.cardId}
+          {' · '}
+          <span className="muted">By:</span> {listing.createdByDisplayName || 'Anonymous'}
+        </div>
+      </div>
+      <div className="market-listing__actions">
+        <button type="button" onClick={() => onAccept?.(listing)} disabled={!canAccept}>
+          Accept
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export default ListingRow;

--- a/frontend/src/pages/Market/hooks/useOpenListings.js
+++ b/frontend/src/pages/Market/hooks/useOpenListings.js
@@ -1,0 +1,33 @@
+import { useEffect, useMemo, useState } from 'react';
+import { subscribeOpenListings } from '../../../lib/marketplace/listings';
+
+export default function useOpenListings({ cardId } = {}) {
+  const [listings, setListings] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const params = useMemo(() => ({ cardId: cardId || undefined }), [cardId]);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+
+    const unsubscribe = subscribeOpenListings(
+      params,
+      (snapshot) => {
+        const next = snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+        setListings(next);
+        setLoading(false);
+      },
+      (err) => {
+        console.error('Failed to load open listings', err);
+        setError(err);
+        setLoading(false);
+      },
+    );
+
+    return () => unsubscribe();
+  }, [params]);
+
+  return { listings, loading, error };
+}

--- a/frontend/src/pages/Market/index.jsx
+++ b/frontend/src/pages/Market/index.jsx
@@ -2,6 +2,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import useOpenListings from './hooks/useOpenListings';
 import ListingRow from './components/ListingRow';
+import { acceptListing } from '../../lib/marketplace/listings';
 import './Market.css';
 
 function MarketPage() {
@@ -9,14 +10,22 @@ function MarketPage() {
   const { user } = useAuth();
   const { listings, loading, error } = useOpenListings();
 
-  const handleAccept = (listing) => {
+  const handleAccept = async (listing) => {
     if (!user) {
       navigate('/auth/login', { state: { from: { pathname: '/market' } } });
       return;
     }
 
-    // Accept flow (trades + atomic update) comes in the next PR.
-    alert('Accept flow coming next. For now you can create and view listings.');
+    try {
+      await acceptListing({
+        listingId: listing.id,
+        acceptedByUid: user.uid,
+        acceptedByDisplayName: user.displayName || user.email,
+      });
+    } catch (err) {
+      console.error('Failed to accept listing', err);
+      alert(err?.message || 'Failed to accept listing');
+    }
   };
 
   return (
@@ -38,6 +47,11 @@ function MarketPage() {
               listing={listing}
               onAccept={handleAccept}
               canAccept={Boolean(user) && listing.createdByUid !== user.uid}
+              canCancel={Boolean(user) && listing.createdByUid === user.uid}
+              onCancel={async (l) => {
+                // Cancel flow will be added next; for now keep UI minimal.
+                alert('Cancel coming next.');
+              }}
             />
           ))}
         </ul>

--- a/frontend/src/pages/Market/index.jsx
+++ b/frontend/src/pages/Market/index.jsx
@@ -1,12 +1,53 @@
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import useOpenListings from './hooks/useOpenListings';
+import ListingRow from './components/ListingRow';
+import './Market.css';
+
 function MarketPage() {
+  const navigate = useNavigate();
+  const { user } = useAuth();
+  const { listings, loading, error } = useOpenListings();
+
+  const handleAccept = (listing) => {
+    if (!user) {
+      navigate('/auth/login', { state: { from: { pathname: '/market' } } });
+      return;
+    }
+
+    // Accept flow (trades + atomic update) comes in the next PR.
+    alert('Accept flow coming next. For now you can create and view listings.');
+  };
+
   return (
     <section>
       <h1>Market</h1>
       <p>Browse active buy (bid) and sell (ask) listings for Lost Tales cards.</p>
-      <p>Sign in to create listings or accept an existing listing.</p>
-      <p>
-        <strong>Status:</strong> Market listings are not implemented yet.
-      </p>
+
+      {error && <p className="muted">Failed to load listings.</p>}
+
+      {loading ? (
+        <p>Loading listings…</p>
+      ) : listings.length === 0 ? (
+        <p className="muted">No open listings yet.</p>
+      ) : (
+        <ul className="market-list">
+          {listings.map((listing) => (
+            <ListingRow
+              key={listing.id}
+              listing={listing}
+              onAccept={handleAccept}
+              canAccept={Boolean(user) && listing.createdByUid !== user.uid}
+            />
+          ))}
+        </ul>
+      )}
+
+      {!user && (
+        <p className="muted" style={{ marginTop: '1rem' }}>
+          Sign in to create listings or accept an existing listing.
+        </p>
+      )}
     </section>
   );
 }

--- a/frontend/src/pages/Market/index.jsx
+++ b/frontend/src/pages/Market/index.jsx
@@ -1,0 +1,14 @@
+function MarketPage() {
+  return (
+    <section>
+      <h1>Market</h1>
+      <p>Browse active buy (bid) and sell (ask) listings for Lost Tales cards.</p>
+      <p>Sign in to create listings or accept an existing listing.</p>
+      <p>
+        <strong>Status:</strong> Market listings are not implemented yet.
+      </p>
+    </section>
+  );
+}
+
+export default MarketPage;

--- a/frontend/src/pages/Market/index.jsx
+++ b/frontend/src/pages/Market/index.jsx
@@ -2,13 +2,28 @@ import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../contexts/AuthContext';
 import useOpenListings from './hooks/useOpenListings';
 import ListingRow from './components/ListingRow';
-import { acceptListing } from '../../lib/marketplace/listings';
+import { acceptListing, cancelListing } from '../../lib/marketplace/listings';
+import { createTrade } from '../../lib/marketplace/trades';
 import './Market.css';
 
 function MarketPage() {
   const navigate = useNavigate();
   const { user } = useAuth();
   const { listings, loading, error } = useOpenListings();
+
+  const handleCancel = async (listing) => {
+    if (!user) {
+      navigate('/auth/login', { state: { from: { pathname: '/market' } } });
+      return;
+    }
+
+    try {
+      await cancelListing({ listingId: listing.id, cancelledByUid: user.uid });
+    } catch (err) {
+      console.error('Failed to cancel listing', err);
+      alert(err?.message || 'Failed to cancel listing');
+    }
+  };
 
   const handleAccept = async (listing) => {
     if (!user) {
@@ -21,6 +36,31 @@ function MarketPage() {
         listingId: listing.id,
         acceptedByUid: user.uid,
         acceptedByDisplayName: user.displayName || user.email,
+      });
+
+      // Create a Trade record (not strictly enforced atomically by rules yet).
+      const listingType = listing.type;
+      const creatorUid = listing.createdByUid;
+      const creatorName = listing.createdByDisplayName || 'Anonymous';
+      const acceptorUid = user.uid;
+      const acceptorName = user.displayName || user.email;
+
+      const buyerUid = listingType === 'ASK' ? acceptorUid : creatorUid;
+      const buyerDisplayName = listingType === 'ASK' ? acceptorName : creatorName;
+      const sellerUid = listingType === 'ASK' ? creatorUid : acceptorUid;
+      const sellerDisplayName = listingType === 'ASK' ? creatorName : acceptorName;
+
+      await createTrade({
+        listingId: listing.id,
+        cardId: listing.cardId,
+        type: listingType,
+        priceCents: listing.priceCents,
+        currency: listing.currency,
+        quantity: listing.quantity || 1,
+        buyerUid,
+        buyerDisplayName,
+        sellerUid,
+        sellerDisplayName,
       });
     } catch (err) {
       console.error('Failed to accept listing', err);
@@ -48,10 +88,7 @@ function MarketPage() {
               onAccept={handleAccept}
               canAccept={Boolean(user) && listing.createdByUid !== user.uid}
               canCancel={Boolean(user) && listing.createdByUid === user.uid}
-              onCancel={async (l) => {
-                // Cancel flow will be added next; for now keep UI minimal.
-                alert('Cancel coming next.');
-              }}
+              onCancel={handleCancel}
             />
           ))}
         </ul>


### PR DESCRIPTION
Adds two MVP behaviors on top of listing acceptance:\n\n- Cancel: listing creator can cancel their OPEN listing (client transaction + existing rules).\n- Trades: create a  document (status=PENDING) after a listing is accepted so we can track multi-user interactions.\n\nFirestore rules\n- Enable trades create (buyer or seller only) + read (buyer/seller).\n- Note: MVP does not strictly enforce atomic coupling of trade creation with listing acceptance yet; can be tightened later (or moved to callable function).\n\nTest (emulator)\n1) User A creates listing\n2) User A cancels listing (it disappears from /market)\n3) User B accepts listing; trade doc appears in Emulator UI (Firestore)