### PR TITLE
Fix add-to-collection quantity increment

### DIFF
--- a/frontend/src/pages/Cards/hooks/useAddToCollection.js
+++ b/frontend/src/pages/Cards/hooks/useAddToCollection.js
@@ -1,9 +1,38 @@
 import { useCallback, useState } from 'react';
-import { addDoc, collection, serverTimestamp } from 'firebase/firestore';
+import {
+  addDoc,
+  collection,
+  doc,
+  getDocs,
+  increment,
+  limit,
+  query,
+  serverTimestamp,
+  updateDoc,
+  where,
+} from 'firebase/firestore';
 import { db } from '../../../lib/firebase';
 import { useAuth } from '../../../contexts/AuthContext';
+import { datasetSkus } from '../../../data/cards';
 
 const COLLECTIONS_PATH = 'collections';
+
+function resolveSkuId({ cardId, finish }) {
+  if (!cardId || !finish) {
+    return null;
+  }
+
+  const normalizedCardId = String(cardId).toUpperCase();
+  const normalizedFinish = String(finish).toUpperCase();
+
+  const match = (datasetSkus ?? []).find(
+    (sku) =>
+      String(sku.cardId).toUpperCase() === normalizedCardId &&
+      String(sku.finish).toUpperCase() === normalizedFinish,
+  );
+
+  return match?.skuId ? String(match.skuId).toUpperCase() : null;
+}
 
 export function useAddToCollection() {
   const { user } = useAuth();
@@ -26,6 +55,9 @@ export function useAddToCollection() {
       setError(null);
 
       try {
+        const normalizedFinish = finish ? String(finish).toUpperCase() : null;
+        const skuId = resolveSkuId({ cardId: card.id, finish: normalizedFinish });
+
         const payload = {
           ownerUid: user.uid,
           cardId: card.id,
@@ -33,9 +65,13 @@ export function useAddToCollection() {
           updatedAt: serverTimestamp(),
         };
 
+        if (skuId) {
+          payload.skuId = skuId;
+        }
+
         // Only include finish if it has a value (matching bulkImport.js pattern)
-        if (finish) {
-          payload.finish = String(finish).toUpperCase();
+        if (normalizedFinish) {
+          payload.finish = normalizedFinish;
         }
 
         if (card.displayName) {
@@ -48,7 +84,51 @@ export function useAddToCollection() {
           payload.category = card.category;
         }
 
-        await addDoc(collection(db, COLLECTIONS_PATH), payload);
+        const collectionsRef = collection(db, COLLECTIONS_PATH);
+
+        // If the entry already exists, increment its quantity instead of creating duplicates.
+        const existingQuery = skuId
+          ? query(
+              collectionsRef,
+              where('ownerUid', '==', user.uid),
+              where('skuId', '==', skuId),
+              limit(1),
+            )
+          : normalizedFinish
+            ? query(
+                collectionsRef,
+                where('ownerUid', '==', user.uid),
+                where('cardId', '==', card.id),
+                where('finish', '==', normalizedFinish),
+                limit(1),
+              )
+            : query(
+                collectionsRef,
+                where('ownerUid', '==', user.uid),
+                where('cardId', '==', card.id),
+                limit(1),
+              );
+
+        const existingSnapshot = await getDocs(existingQuery);
+        const existingDoc = existingSnapshot.docs[0] ?? null;
+
+        if (existingDoc) {
+          const ref = doc(collectionsRef, existingDoc.id);
+          await updateDoc(ref, {
+            quantity: increment(quantity),
+            updatedAt: serverTimestamp(),
+            ...(payload.finish ? { finish: payload.finish } : {}),
+            ...(payload.skuId ? { skuId: payload.skuId } : {}),
+            ...(payload.displayName ? { displayName: payload.displayName } : {}),
+            ...(payload.storyTitle ? { storyTitle: payload.storyTitle } : {}),
+            ...(payload.category ? { category: payload.category } : {}),
+          });
+
+          setStatus('success');
+          return { id: existingDoc.id, ...payload };
+        }
+
+        await addDoc(collectionsRef, payload);
         setStatus('success');
         return payload;
       } catch (err) {


### PR DESCRIPTION
When adding a card that's already in a user's collection, increment the existing entry's quantity instead of creating duplicate docs with quantity=1. Also stores skuId when resolvable from cardId+finish.