### PR TITLE
test(functions): add marketplace validation helpers + tests

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,12 @@
 const { onCall, HttpsError } = require('firebase-functions/v2/https');
 const admin = require('firebase-admin');
 
+const {
+  assertListingType,
+  assertPriceCents,
+  assertUsdCurrency,
+} = require('./lib/marketplaceValidation');
+
 if (!admin.apps.length) {
   admin.initializeApp();
 }
@@ -45,17 +51,11 @@ exports.acceptListing = onCall(async (request) => {
       throw new HttpsError('failed-precondition', 'Cannot accept your own listing');
     }
 
-    if (listing.currency !== 'USD') {
-      throw new HttpsError('failed-precondition', 'Unsupported currency');
-    }
-
-    // MVP constraints (keep things simple + consistent)
-    asInt(listing.priceCents, 'priceCents');
+    assertUsdCurrency(listing.currency);
+    assertPriceCents(listing.priceCents);
 
     const listingType = listing.type;
-    if (listingType !== 'BID' && listingType !== 'ASK') {
-      throw new HttpsError('failed-precondition', 'Invalid listing type');
-    }
+    assertListingType(listingType);
 
     const creatorUid = listing.createdByUid;
     const creatorName = listing.createdByDisplayName || 'Anonymous';

--- a/functions/lib/marketplaceValidation.js
+++ b/functions/lib/marketplaceValidation.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const { HttpsError } = require('firebase-functions/v2/https');
+const { asInt } = require('./validation');
+
+function assertUsdCurrency(currency) {
+  if (currency !== 'USD') {
+    throw new HttpsError('failed-precondition', 'Unsupported currency');
+  }
+}
+
+function assertListingType(listingType) {
+  if (listingType !== 'BID' && listingType !== 'ASK') {
+    throw new HttpsError('failed-precondition', 'Invalid listing type');
+  }
+}
+
+function assertPriceCents(priceCents) {
+  // MVP constraints (keep things simple + consistent)
+  asInt(priceCents, 'priceCents');
+}
+
+module.exports = {
+  assertUsdCurrency,
+  assertListingType,
+  assertPriceCents,
+};

--- a/functions/lib/marketplaceValidation.test.js
+++ b/functions/lib/marketplaceValidation.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  assertListingType,
+  assertPriceCents,
+  assertUsdCurrency,
+} = require('./marketplaceValidation');
+
+test('assertUsdCurrency allows USD', () => {
+  assert.doesNotThrow(() => assertUsdCurrency('USD'));
+});
+
+test('assertUsdCurrency throws for non-USD', () => {
+  assert.throws(() => assertUsdCurrency('EUR'), (err) => {
+    assert.equal(err?.code, 'failed-precondition');
+    assert.match(String(err?.message ?? ''), /Unsupported currency/);
+    return true;
+  });
+});
+
+test('assertListingType allows BID/ASK', () => {
+  assert.doesNotThrow(() => assertListingType('BID'));
+  assert.doesNotThrow(() => assertListingType('ASK'));
+});
+
+test('assertListingType throws for invalid values', () => {
+  for (const value of ['BUY', 'SELL', '', null, undefined]) {
+    assert.throws(() => assertListingType(value), (err) => {
+      assert.equal(err?.code, 'failed-precondition');
+      assert.match(String(err?.message ?? ''), /Invalid listing type/);
+      return true;
+    });
+  }
+});
+
+test('assertPriceCents allows integer numbers', () => {
+  assert.doesNotThrow(() => assertPriceCents(0));
+  assert.doesNotThrow(() => assertPriceCents(1));
+  assert.doesNotThrow(() => assertPriceCents(9999));
+});
+
+test('assertPriceCents throws for non-integers', () => {
+  for (const value of [1.25, NaN, Infinity, '1', null, undefined]) {
+    assert.throws(() => assertPriceCents(value), (err) => {
+      assert.equal(err?.code, 'invalid-argument');
+      return true;
+    });
+  }
+});

--- a/functions/lib/validation.js
+++ b/functions/lib/validation.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { HttpsError } = require('firebase-functions/v2/https');
+
+function asInt(value, field) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || Math.floor(value) !== value) {
+    throw new HttpsError('invalid-argument', `${field} must be an integer`);
+  }
+  return value;
+}
+
+module.exports = {
+  asInt,
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,9 @@
   },
   "main": "index.js",
   "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.4.0"


### PR DESCRIPTION
Extracts pure validation helpers used by acceptListing (currency, listing type, priceCents) and adds node:test coverage. Also adds a minimal 
> workspace@1.0.0 test
> echo "Error: no test specified" && exit 1

Error: no test specified script for functions.