### PR TITLE
Add auth-null guard to logout action

### DIFF
--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -85,6 +85,14 @@ export function AuthProvider({ children }) {
   );
 
   const logout = useCallback(async () => {
+    if (!auth) {
+      const err = new Error(
+        'Authentication is not configured. Set VITE_FIREBASE_* variables in frontend/.env to enable sign-out.',
+      );
+      handleError(err);
+      throw err;
+    }
+
     clearError();
     try {
       await signOut(auth);
@@ -166,4 +174,3 @@ export function useAuth() {
   }
   return context;
 }
-


### PR DESCRIPTION
## Summary
- add the same not-configured guard pattern to logout that other auth actions already use
- surface a consistent actionable error when Firebase auth env vars are missing

## Validation
- static code review for AuthContext changes
- no frontend build run in isolated worktree (vite dependency unavailable)