### PR TITLE
feat(functions): add create/cancel listing callables

### DIFF
--- a/functions/lib/marketplaceValidation.js
+++ b/functions/lib/marketplaceValidation.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { HttpsError } = require('firebase-functions/v2/https');
+const { asInt } = require('./validation');
+
+function assertUsdCurrency(currency) {
+  if (currency !== 'USD') {
+    throw new HttpsError('failed-precondition', 'Unsupported currency');
+  }
+}
+
+function assertListingType(listingType) {
+  if (listingType !== 'BID' && listingType !== 'ASK') {
+    throw new HttpsError('failed-precondition', 'Invalid listing type');
+  }
+}
+
+function assertPriceCents(priceCents) {
+  asInt(priceCents, 'priceCents');
+  if (priceCents <= 0) {
+    throw new HttpsError('failed-precondition', 'priceCents must be > 0');
+  }
+  // Basic sanity cap (avoid typos like $999999)
+  if (priceCents > 10000000) {
+    throw new HttpsError('failed-precondition', 'priceCents is too large');
+  }
+}
+
+function assertQuantity(quantity) {
+  asInt(quantity, 'quantity');
+  if (quantity !== 1) {
+    throw new HttpsError('failed-precondition', 'Only quantity=1 is supported for MVP');
+  }
+}
+
+function assertCardId(cardId) {
+  if (typeof cardId !== 'string' || cardId.trim().length === 0) {
+    throw new HttpsError('invalid-argument', 'cardId is required');
+  }
+}
+
+module.exports = {
+  assertUsdCurrency,
+  assertListingType,
+  assertPriceCents,
+  assertQuantity,
+  assertCardId,
+};

--- a/functions/lib/marketplaceValidation.test.js
+++ b/functions/lib/marketplaceValidation.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  assertListingType,
+  assertPriceCents,
+  assertUsdCurrency,
+  assertQuantity,
+  assertCardId,
+} = require('./marketplaceValidation');
+
+test('assertUsdCurrency allows USD', () => {
+  assert.doesNotThrow(() => assertUsdCurrency('USD'));
+});
+
+test('assertUsdCurrency throws for non-USD', () => {
+  assert.throws(() => assertUsdCurrency('EUR'), (err) => {
+    assert.equal(err?.code, 'failed-precondition');
+    assert.match(String(err?.message ?? ''), /Unsupported currency/);
+    return true;
+  });
+});
+
+test('assertListingType allows BID/ASK', () => {
+  assert.doesNotThrow(() => assertListingType('BID'));
+  assert.doesNotThrow(() => assertListingType('ASK'));
+});
+
+test('assertListingType throws for invalid values', () => {
+  for (const value of ['BUY', 'SELL', '', null, undefined]) {
+    assert.throws(() => assertListingType(value), (err) => {
+      assert.equal(err?.code, 'failed-precondition');
+      assert.match(String(err?.message ?? ''), /Invalid listing type/);
+      return true;
+    });
+  }
+});
+
+test('assertPriceCents allows integer cents > 0', () => {
+  assert.doesNotThrow(() => assertPriceCents(1));
+  assert.doesNotThrow(() => assertPriceCents(9999));
+});
+
+test('assertPriceCents throws for non-integers', () => {
+  for (const value of [1.25, NaN, Infinity, '1', null, undefined]) {
+    assert.throws(() => assertPriceCents(value), (err) => {
+      assert.equal(err?.code, 'invalid-argument');
+      return true;
+    });
+  }
+});
+
+test('assertPriceCents throws for <= 0', () => {
+  for (const value of [0, -1]) {
+    assert.throws(() => assertPriceCents(value), (err) => {
+      assert.equal(err?.code, 'failed-precondition');
+      assert.match(String(err?.message ?? ''), /> 0/);
+      return true;
+    });
+  }
+});
+
+test('assertQuantity allows 1 only', () => {
+  assert.doesNotThrow(() => assertQuantity(1));
+  assert.throws(() => assertQuantity(2), (err) => {
+    assert.equal(err?.code, 'failed-precondition');
+    return true;
+  });
+});
+
+test('assertCardId requires non-empty string', () => {
+  assert.doesNotThrow(() => assertCardId('LT24-001'));
+  for (const value of ['', '  ', null, undefined, 123]) {
+    assert.throws(() => assertCardId(value), (err) => {
+      assert.equal(err?.code, 'invalid-argument');
+      return true;
+    });
+  }
+});

--- a/functions/lib/validation.js
+++ b/functions/lib/validation.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const { HttpsError } = require('firebase-functions/v2/https');
+
+function asInt(value, field) {
+  if (typeof value !== 'number' || !Number.isFinite(value) || Math.floor(value) !== value) {
+    throw new HttpsError('invalid-argument', `${field} must be an integer`);
+  }
+  return value;
+}
+
+module.exports = {
+  asInt,
+};

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,6 +6,9 @@
   },
   "main": "index.js",
   "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "firebase-admin": "^12.6.0",
     "firebase-functions": "^6.4.0"


### PR DESCRIPTION
Adds callable Cloud Functions for createListing and cancelListing, plus shared marketplace validation helpers + node:test coverage.\n\nNext steps (separate PR): update frontend to use these callables and tighten Firestore rules.