### PR TITLE
docs: expand AGENTS.md for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,27 +6,54 @@
 
 Lost Tales Marketplace is a single-product Vite + React 18 SPA (`frontend/`) backed by Firebase (Auth, Firestore, Cloud Functions in `functions/`). There is no custom backend server; all server-side logic runs as Firebase callable Cloud Functions.
 
+### Repository layout
+
+| Path | Role |
+|------|------|
+| `frontend/` | Vite + React app; run dev server and frontend tests here |
+| `functions/` | Cloud Functions (`firebase-functions` + `firebase-admin`); emulator loads this code |
+| `firebase.json`, `.firebaserc` | Emulator ports, Firestore rules path, default Firebase project (`storydeck-16`) |
+| `firestore.rules`, `firestore.indexes.json` | Firestore security rules and composite indexes |
+
+### Setup
+
+1. **Repo root** (Biome): `npm install`
+2. **Frontend**: `cd frontend && npm install`
+3. **Functions** (if you change or debug callable code with the emulator): `cd functions && npm install`
+
+Default Firebase project id matches `.firebaserc`: `storydeck-16`.
+
 ### Running locally
 
 Two processes are needed for full local development:
 
 1. **Firebase Emulators** (Auth on 9099, Firestore on 8080, Functions on 5001, UI on 4000):
-   ```
+
+   ```bash
    firebase emulators:start --project storydeck-16
    ```
-   Requires Java 11+ (pre-installed in the VM). The emulators take ~10-15 s to start; wait for the "All emulators ready" banner before interacting.
+
+   If the Firebase CLI is not installed globally, use:
+
+   ```bash
+   npx firebase-tools emulators:start --project storydeck-16
+   ```
+
+   Requires Java 11+ (pre-installed in the VM). The emulators take ~10–15 s to start; wait for the "All emulators ready" banner before interacting.
 
 2. **Vite Dev Server** (port 5173):
-   ```
+
+   ```bash
    cd frontend && npm run dev -- --host 0.0.0.0
    ```
 
-The frontend `.env` must have `VITE_USE_EMULATORS=true` and dummy `VITE_FIREBASE_*` values so the Firebase SDK initializes and connects to the local emulators. A working `.env` is created during setup; if it is missing, copy `frontend/.env.emulator.example` to `frontend/.env` and add placeholder values for the required `VITE_FIREBASE_*` keys (any non-empty string works with emulators).
+The frontend `.env` must have `VITE_USE_EMULATORS=true` and dummy `VITE_FIREBASE_*` values so the Firebase SDK initializes and connects to the local emulators. A working `.env` is created during setup; if it is missing, copy `frontend/.env.emulator.example` to `frontend/.env` and add placeholder values for the required `VITE_FIREBASE_*` keys (any non-empty string works with emulators). For production-shaped config, start from `frontend/.env.example`.
 
 ### Lint / Test / Build
 
 - **Biome** (format, lint, import organization) runs from the repo root after `npm install`:
   - `npm run format` — write formatting
+  - `npm run lint` — lint only (no write)
   - `npm run check` — format, lint, and organize imports (writes fixes)
   - `npm run ci` — read-only check for CI (`biome ci .`)
 - **Unit & integration tests**: Vitest + Testing Library (`cd frontend && npm run test`, or `npm run test` from the repo root). Tests live next to source as `*.test.{js,jsx}`; setup is `frontend/src/test/setup.js`. Prefer queries from [Testing Library priority](https://testing-library.com/docs/queries/about#priority) (role, label, placeholder, text) and `userEvent` over `fireEvent` where it reflects real interaction.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates [AGENTS.md](AGENTS.md) so Cursor Cloud agents and contributors have a single place for layout, setup, and tooling.

## Changes

- Add a **repository layout** table (`frontend/`, `functions/`, Firebase config files).
- Add **setup** steps: `npm install` at root, frontend, and functions when working on callable code.
- Document **`npm run lint`** (read-only Biome lint) alongside format/check/ci.
- Note **`npx firebase-tools emulators:start`** when the Firebase CLI is not global.
- Mention **`frontend/.env.example`** for production-shaped env alongside the emulator example.

## Verification

- `npm install` and `npm run ci` at repo root pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d091a02-e7ad-4db3-b51b-242e15fed04a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d091a02-e7ad-4db3-b51b-242e15fed04a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

