### PR TITLE
Improve RTL coverage for auth and collection entry workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ node_modules/
 # Build outputs
 dist/
 build/
+frontend/coverage/
 
 # Environment variables
 .env

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^5.1.3",
+        "@vitest/coverage-v8": "^3.2.4",
         "jsdom": "^26.0.0",
         "vite": "^6.4.1",
         "vitest": "^3.0.5"
@@ -30,6 +31,20 @@
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
@@ -338,6 +353,16 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -1065,6 +1090,119 @@
         "node": ">=6"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1108,6 +1246,17 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@playwright/test": {
@@ -1417,6 +1566,40 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
@@ -1584,6 +1767,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -1592,6 +1804,19 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
+      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1721,6 +1946,21 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -1808,6 +2048,13 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
@@ -1998,6 +2245,23 @@
         }
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2015,6 +2279,71 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -2027,6 +2356,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
@@ -2103,6 +2439,83 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2233,6 +2646,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -2241,6 +2695,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
+      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -2282,6 +2762,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/parse5": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
@@ -2294,6 +2781,40 @@
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -2655,12 +3176,48 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2698,10 +3255,40 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2742,12 +3329,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3155,6 +3770,22 @@
         "node": ">=18"
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -3176,6 +3807,25 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
@@ -23,6 +24,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^5.1.3",
+    "@vitest/coverage-v8": "^3.2.4",
     "jsdom": "^26.0.0",
     "vite": "^6.4.1",
     "vitest": "^3.0.5"

--- a/frontend/src/components/Auth/AuthGuard.test.jsx
+++ b/frontend/src/components/Auth/AuthGuard.test.jsx
@@ -1,0 +1,106 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import AuthGuard from "./AuthGuard.jsx";
+
+function makeAuthMock() {
+  const state = {
+    deferInitialCallback: false,
+    initialUser: null,
+  };
+  let pendingCallback = null;
+  const fireAuthState = (user) => {
+    pendingCallback?.(user);
+  };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    pendingCallback = callback;
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    fireAuthState,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() => Promise.resolve({ user: {} })),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function renderGuard(initialPath = "/protected", options = {}) {
+  const { fallback = <span>Loading guard</span> } = options;
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <Routes>
+          <Route
+            path="/protected"
+            element={
+              <AuthGuard fallback={fallback}>
+                <h1>Protected</h1>
+              </AuthGuard>
+            }
+          />
+          <Route path="/auth/login" element={<h1>Login page</h1>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthGuard", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("renders fallback while auth is loading", async () => {
+    authMock.state.deferInitialCallback = true;
+    renderGuard();
+
+    expect(screen.getByText("Loading guard")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: /^protected$/i })).not.toBeInTheDocument();
+
+    authMock.fireAuthState(null);
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /^login page$/i })).toBeInTheDocument();
+    });
+  });
+
+  it("redirects signed-out users to login with state.from", async () => {
+    renderGuard();
+
+    expect(await screen.findByRole("heading", { name: /^login page$/i })).toBeInTheDocument();
+  });
+
+  it("renders children when signed in", async () => {
+    authMock.state.initialUser = { uid: "u1", email: "in@example.com" };
+    renderGuard();
+
+    expect(await screen.findByRole("heading", { name: /^protected$/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Auth/AuthModal.test.jsx
+++ b/frontend/src/components/Auth/AuthModal.test.jsx
@@ -1,0 +1,127 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import AuthModal from "./AuthModal.jsx";
+
+function makeAuthMock() {
+  const state = {
+    deferInitialCallback: false,
+    initialUser: null,
+  };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() =>
+      Promise.resolve({ user: { uid: "new-user", email: "n@example.com" } }),
+    ),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function renderModal({ isOpen = true, onClose = vi.fn() } = {}) {
+  return render(
+    <AuthProvider>
+      <AuthModal isOpen={isOpen} onClose={onClose} />
+    </AuthProvider>,
+  );
+}
+
+describe("AuthModal", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("returns null when closed", () => {
+    const { container } = renderModal({ isOpen: false });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("submits sign-in and calls onClose on success", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await screen.findByRole("heading", { name: /^sign in$/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "a@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(authMock.signInWithEmailAndPassword).toHaveBeenCalled();
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("switches to register and creates an account", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await screen.findByRole("heading", { name: /^sign in$/i });
+    await user.click(screen.getByRole("button", { name: /need an account/i }));
+
+    expect(await screen.findByRole("heading", { name: /create account/i })).toBeInTheDocument();
+
+    await user.type(screen.getByRole("textbox", { name: /display name/i }), "Modal User");
+    await user.type(screen.getByRole("textbox", { name: /^email$/i }), "modal@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(authMock.createUserWithEmailAndPassword).toHaveBeenCalled();
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("switches to forgot password flow from sign-in", async () => {
+    const user = userEvent.setup();
+    renderModal();
+
+    await screen.findByRole("heading", { name: /^sign in$/i });
+    await user.click(screen.getByRole("button", { name: /forgot password/i }));
+
+    expect(await screen.findByRole("heading", { name: /reset password/i })).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^password$/i)).not.toBeInTheDocument();
+  });
+
+  it("closes when the close control is activated", async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    renderModal({ onClose });
+
+    await screen.findByRole("heading", { name: /^sign in$/i });
+    await user.click(screen.getByRole("button", { name: "×" }));
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Auth/SocialLoginButtons.test.jsx
+++ b/frontend/src/components/Auth/SocialLoginButtons.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import SocialLoginButtons from "./SocialLoginButtons.jsx";
+
+const loginWithGoogle = vi.fn(() => Promise.resolve());
+const loginWithGithub = vi.fn(() => Promise.resolve());
+
+vi.mock("../../contexts/AuthContext.jsx", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    useAuth: () => ({
+      loginWithGoogle,
+      loginWithGithub,
+    }),
+  };
+});
+
+describe("SocialLoginButtons", () => {
+  it("invokes Google and GitHub sign-in handlers", async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+
+    render(<SocialLoginButtons onSuccess={onSuccess} />);
+
+    await user.click(screen.getByRole("button", { name: /^google$/i }));
+    expect(loginWithGoogle).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: /^github$/i }));
+    expect(loginWithGithub).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/hooks/useAuthGuard.test.jsx
+++ b/frontend/src/hooks/useAuthGuard.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../contexts/AuthContext.jsx";
+import { useAuthGuard } from "./useAuthGuard.js";
+
+function makeAuthMock() {
+  const state = { deferInitialCallback: false, initialUser: null };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() => Promise.resolve({ user: {} })),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function GuardProbe() {
+  const { isAuthenticated, loading, redirectState } = useAuthGuard();
+  return (
+    <div>
+      <span data-testid="loading">{loading ? "loading" : "ready"}</span>
+      <span data-testid="auth">{isAuthenticated ? "in" : "out"}</span>
+      <span data-testid="from">{redirectState.from?.pathname ?? ""}</span>
+    </div>
+  );
+}
+
+function renderProbe(initialPath = "/here") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/here" element={<GuardProbe />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("useAuthGuard", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("reports signed-out state and captures the current path for redirects", async () => {
+    renderProbe("/here");
+
+    expect(await screen.findByTestId("loading")).toHaveTextContent("ready");
+    expect(screen.getByTestId("auth")).toHaveTextContent("out");
+    expect(screen.getByTestId("from")).toHaveTextContent("/here");
+  });
+
+  it("reports authenticated when a user is present", async () => {
+    authMock.state.initialUser = { uid: "1", email: "a@b.com" };
+    renderProbe();
+
+    expect(await screen.findByTestId("auth")).toHaveTextContent("in");
+  });
+});

--- a/frontend/src/hooks/useRequireAuth.test.jsx
+++ b/frontend/src/hooks/useRequireAuth.test.jsx
@@ -1,0 +1,97 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../contexts/AuthContext.jsx";
+import { useRequireAuth } from "./useRequireAuth.js";
+
+function makeAuthMock() {
+  const state = { deferInitialCallback: false, initialUser: null };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() => Promise.resolve({ user: {} })),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function SecretPage() {
+  const location = useLocation();
+  const { user, loading } = useRequireAuth();
+
+  if (loading) {
+    return <p>Loading session</p>;
+  }
+  if (!user) {
+    return <p>Should redirect</p>;
+  }
+
+  return (
+    <div>
+      <h1>Secret</h1>
+      <p>{location.pathname}</p>
+    </div>
+  );
+}
+
+function renderSecret(initialPath = "/secret") {
+  return render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/secret" element={<SecretPage />} />
+          <Route path="/auth/login" element={<h1>Login</h1>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("useRequireAuth", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("navigates to login when unauthenticated after loading", async () => {
+    renderSecret("/secret");
+
+    expect(await screen.findByRole("heading", { name: /^login$/i })).toBeInTheDocument();
+  });
+
+  it("passes through when a user exists", async () => {
+    authMock.state.initialUser = { uid: "1", email: "a@b.com" };
+    renderSecret("/secret");
+
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /^secret$/i })).toBeInTheDocument();
+    });
+    expect(screen.getByText("/secret")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Auth/ForgotPassword.test.jsx
+++ b/frontend/src/pages/Auth/ForgotPassword.test.jsx
@@ -1,0 +1,109 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import ForgotPassword from "./ForgotPassword.jsx";
+
+function makeAuthMock() {
+  const state = {
+    deferInitialCallback: false,
+    initialUser: null,
+  };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() =>
+      Promise.resolve({ user: { uid: "new-user", email: "n@example.com" } }),
+    ),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function renderForgotPassword() {
+  return render(
+    <MemoryRouter initialEntries={["/auth/forgot"]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/auth/forgot" element={<ForgotPassword />} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("ForgotPassword", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("sends a password reset email and shows confirmation", async () => {
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await screen.findByRole("heading", { name: /reset your password/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "recover@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset email/i }));
+
+    await waitFor(() => {
+      expect(authMock.sendPasswordResetEmail).toHaveBeenCalled();
+    });
+
+    expect(
+      await screen.findByText(/check your inbox for a password reset link/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces reset errors from the auth context", async () => {
+    authMock.sendPasswordResetEmail.mockRejectedValueOnce(new Error("User not found"));
+
+    const user = userEvent.setup();
+    renderForgotPassword();
+
+    await screen.findByRole("heading", { name: /reset your password/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "missing@example.com");
+    await user.click(screen.getByRole("button", { name: /send reset email/i }));
+
+    expect(await screen.findByText("User not found")).toBeInTheDocument();
+  });
+
+  it("links back to sign in", async () => {
+    renderForgotPassword();
+    await screen.findByRole("heading", { name: /reset your password/i });
+
+    expect(screen.getByRole("link", { name: /return to sign in/i })).toHaveAttribute(
+      "href",
+      "/auth/login",
+    );
+  });
+});

--- a/frontend/src/pages/Auth/Login.test.jsx
+++ b/frontend/src/pages/Auth/Login.test.jsx
@@ -1,0 +1,142 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import Login from "./Login.jsx";
+
+function makeAuthMock() {
+  const state = {
+    deferInitialCallback: false,
+    initialUser: null,
+  };
+  let pendingCallback = null;
+  const fireAuthState = (user) => {
+    pendingCallback?.(user);
+  };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    pendingCallback = callback;
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    fireAuthState,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() =>
+      Promise.resolve({ user: { uid: "new-user", email: "n@example.com" } }),
+    ),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function renderLogin(initialPath = "/auth/login", routeState = null) {
+  return render(
+    <MemoryRouter initialEntries={[{ pathname: initialPath, state: routeState }]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/auth/login" element={<Login />} />
+          <Route path="/collections" element={<h1>Collection</h1>} />
+          <Route path="/market" element={<h1>Market</h1>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Login", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    authMock.state.deferInitialCallback = false;
+  });
+
+  it("submits email and password and navigates to the default redirect (/collections)", async () => {
+    const user = userEvent.setup();
+    renderLogin();
+
+    await screen.findByRole("heading", { name: /sign in to lost tales marketplace/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "a@example.com");
+    await user.type(screen.getByLabelText(/password/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(authMock.signInWithEmailAndPassword).toHaveBeenCalledWith(
+        expect.anything(),
+        "a@example.com",
+        "secret12",
+      );
+    });
+
+    expect(await screen.findByRole("heading", { name: /^collection$/i })).toBeInTheDocument();
+  });
+
+  it("redirects to location.state.from when present", async () => {
+    const user = userEvent.setup();
+    renderLogin("/auth/login", { from: { pathname: "/market" } });
+
+    await screen.findByRole("heading", { name: /sign in to lost tales marketplace/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "a@example.com");
+    await user.type(screen.getByLabelText(/password/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    expect(await screen.findByRole("heading", { name: /^market$/i })).toBeInTheDocument();
+  });
+
+  it("renders auth error message from context", async () => {
+    authMock.signInWithEmailAndPassword.mockRejectedValueOnce(new Error("Invalid credentials"));
+
+    const user = userEvent.setup();
+    renderLogin();
+
+    await screen.findByRole("heading", { name: /sign in to lost tales marketplace/i });
+
+    await user.type(screen.getByRole("textbox", { name: /email/i }), "a@example.com");
+    await user.type(screen.getByLabelText(/password/i), "wrong");
+    await user.click(screen.getByRole("button", { name: /^sign in$/i }));
+
+    expect(await screen.findByText("Invalid credentials")).toBeInTheDocument();
+  });
+
+  it("links to forgot password and register", async () => {
+    renderLogin();
+    await screen.findByRole("heading", { name: /sign in to lost tales marketplace/i });
+
+    expect(screen.getByRole("link", { name: /forgot password/i })).toHaveAttribute(
+      "href",
+      "/auth/forgot",
+    );
+    expect(screen.getByRole("link", { name: /need an account/i })).toHaveAttribute(
+      "href",
+      "/auth/register",
+    );
+  });
+});

--- a/frontend/src/pages/Auth/Register.test.jsx
+++ b/frontend/src/pages/Auth/Register.test.jsx
@@ -1,0 +1,115 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import Register from "./Register.jsx";
+
+function makeAuthMock() {
+  const state = {
+    deferInitialCallback: false,
+    initialUser: null,
+  };
+  const onAuthStateChanged = vi.fn((_auth, callback) => {
+    if (!state.deferInitialCallback) {
+      queueMicrotask(() => callback(state.initialUser));
+    }
+    return vi.fn();
+  });
+  return {
+    state,
+    onAuthStateChanged,
+    signInWithEmailAndPassword: vi.fn(() => Promise.resolve()),
+    createUserWithEmailAndPassword: vi.fn(() =>
+      Promise.resolve({ user: { uid: "new-user", email: "n@example.com" } }),
+    ),
+    sendPasswordResetEmail: vi.fn(() => Promise.resolve()),
+    signOut: vi.fn(() => Promise.resolve()),
+    signInWithPopup: vi.fn(() => Promise.resolve()),
+    updateProfile: vi.fn(() => Promise.resolve()),
+  };
+}
+
+const authMock = vi.hoisted(() => makeAuthMock());
+
+vi.mock("firebase/auth", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    onAuthStateChanged: authMock.onAuthStateChanged,
+    signInWithEmailAndPassword: authMock.signInWithEmailAndPassword,
+    createUserWithEmailAndPassword: authMock.createUserWithEmailAndPassword,
+    sendPasswordResetEmail: authMock.sendPasswordResetEmail,
+    signOut: authMock.signOut,
+    signInWithPopup: authMock.signInWithPopup,
+    updateProfile: authMock.updateProfile,
+  };
+});
+
+function renderRegister() {
+  return render(
+    <MemoryRouter initialEntries={["/auth/register"]}>
+      <AuthProvider>
+        <Routes>
+          <Route path="/auth/register" element={<Register />} />
+          <Route path="/collections" element={<h1>Collection</h1>} />
+        </Routes>
+      </AuthProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("Register", () => {
+  beforeEach(() => {
+    authMock.state.deferInitialCallback = false;
+    authMock.state.initialUser = null;
+    vi.clearAllMocks();
+  });
+
+  it("creates an account and navigates to /collections", async () => {
+    const user = userEvent.setup();
+    renderRegister();
+
+    await screen.findByRole("heading", { name: /create your lost tales account/i });
+
+    await user.type(screen.getByRole("textbox", { name: /display name/i }), "Test User");
+    await user.type(screen.getByRole("textbox", { name: /^email$/i }), "new@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(authMock.createUserWithEmailAndPassword).toHaveBeenCalled();
+    });
+
+    expect(authMock.updateProfile).toHaveBeenCalled();
+    expect(await screen.findByRole("heading", { name: /^collection$/i })).toBeInTheDocument();
+  });
+
+  it("shows registration errors from the auth context", async () => {
+    authMock.createUserWithEmailAndPassword.mockRejectedValueOnce(
+      new Error("Email already in use"),
+    );
+
+    const user = userEvent.setup();
+    renderRegister();
+
+    await screen.findByRole("heading", { name: /create your lost tales account/i });
+
+    await user.type(screen.getByRole("textbox", { name: /display name/i }), "Test User");
+    await user.type(screen.getByRole("textbox", { name: /^email$/i }), "taken@example.com");
+    await user.type(screen.getByLabelText(/^password$/i), "secret12");
+    await user.click(screen.getByRole("button", { name: /^sign up$/i }));
+
+    expect(await screen.findByText("Email already in use")).toBeInTheDocument();
+  });
+
+  it("links back to sign in", async () => {
+    renderRegister();
+    await screen.findByRole("heading", { name: /create your lost tales account/i });
+
+    expect(screen.getByRole("link", { name: /already have an account/i })).toHaveAttribute(
+      "href",
+      "/auth/login",
+    );
+  });
+});

--- a/frontend/src/pages/Collectibles/components/AddToCollectionButton.test.jsx
+++ b/frontend/src/pages/Collectibles/components/AddToCollectionButton.test.jsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import AddToCollectionButton from "./AddToCollectionButton.jsx";
+
+const openAuthModal = vi.fn();
+const addToCollection = vi.fn(() => Promise.resolve());
+const reset = vi.fn();
+
+const hookState = vi.hoisted(() => ({
+  user: null,
+  status: "idle",
+  error: null,
+}));
+
+vi.mock("../../../contexts/AuthModalContext.jsx", () => ({
+  useAuthModal: () => ({ openAuthModal }),
+}));
+
+vi.mock("../hooks/useAddToCollection.js", () => ({
+  useAddToCollection: () => ({
+    addToCollection,
+    status: hookState.status,
+    error: hookState.error,
+    user: hookState.user,
+    reset,
+  }),
+}));
+
+const sampleCard = {
+  id: "card-1",
+  finishes: ["DUN", "FOIL"],
+};
+
+describe("AddToCollectionButton", () => {
+  beforeEach(() => {
+    hookState.user = null;
+    hookState.status = "idle";
+    hookState.error = null;
+    vi.clearAllMocks();
+  });
+
+  it("opens the auth modal when signed out", async () => {
+    const user = userEvent.setup();
+    render(<AddToCollectionButton collectible={sampleCard} />);
+
+    await user.click(screen.getByRole("button", { name: /^add dun$/i }));
+
+    expect(openAuthModal).toHaveBeenCalledWith({ reason: "add-to-collection" });
+    expect(addToCollection).not.toHaveBeenCalled();
+  });
+
+  it("calls addToCollection when signed in", async () => {
+    hookState.user = { uid: "u1" };
+    const user = userEvent.setup();
+    render(<AddToCollectionButton collectible={sampleCard} />);
+
+    await user.click(screen.getByRole("button", { name: /^add foil$/i }));
+
+    expect(addToCollection).toHaveBeenCalledWith({
+      card: sampleCard,
+      finish: "FOIL",
+      quantity: 1,
+    });
+    expect(openAuthModal).not.toHaveBeenCalled();
+  });
+
+  it("shows a message when no finishes exist", () => {
+    render(<AddToCollectionButton collectible={{ id: "x", finishes: [] }} />);
+
+    expect(screen.getByText(/no finishes available/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/test/setup.js
+++ b/frontend/src/test/setup.js
@@ -1,1 +1,7 @@
+import { cleanup } from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,5 +9,18 @@ export default defineConfig({
     include: ["src/**/*.{test,spec}.{js,jsx}", "src/**/__tests__/**/*.{js,jsx}"],
     setupFiles: ["./src/test/setup.js"],
     css: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "text-summary", "html"],
+      reportsDirectory: "./coverage",
+      include: ["src/**/*.{js,jsx}"],
+      exclude: [
+        "src/**/*.test.{js,jsx}",
+        "src/**/__tests__/**",
+        "src/main.jsx",
+        "src/test/**",
+        "src/data/**",
+      ],
+    },
   },
 });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "lint": "biome lint .",
     "check": "biome check --write .",
     "ci": "biome ci .",
-    "test": "npm run test --prefix frontend"
+    "test": "npm run test --prefix frontend",
+    "test:coverage": "npm run test:coverage --prefix frontend"
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.8"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Vitest V8 coverage reporting, fixes Testing Library cleanup between tests (prevents leftover DOM from prior cases), and introduces RTL tests focused on high-traffic flows: email/password auth pages, modal auth, route guards, social login buttons, and adding collectibles when signed in vs prompting sign-in.

## How to verify

- From the repo root: `npm run test` (or `cd frontend && npm run test`).
- Coverage: `npm run test:coverage` (HTML report under `frontend/coverage/`).

## Notes

- Statement coverage for `src/` rises from ~19% to ~30%; auth pages, hooks under `src/hooks/`, `AuthGuard`, and most of `AddToCollectionButton` are now exercised.
- Large pages (Market, Collection, Account) remain mostly untested; follow-up could mock Firestore/Functions for narrower component tests.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efb3eb1d-106d-41f6-bcb0-2e5a9848fb65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efb3eb1d-106d-41f6-bcb0-2e5a9848fb65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

