### PR TITLE
test(auth): Vitest/RTL tests for SocialLoginButtons

### DIFF
--- a/frontend/src/components/Auth/SocialLoginButtons.test.jsx
+++ b/frontend/src/components/Auth/SocialLoginButtons.test.jsx
@@ -1,0 +1,122 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthProvider } from "../../contexts/AuthContext.jsx";
+import SocialLoginButtons from "./SocialLoginButtons.jsx";
+
+const { mockAuth, mockGoogleProvider, mockGithubProvider, signInWithPopup } = vi.hoisted(() => {
+  const auth = { _mock: "auth" };
+  return {
+    mockAuth: auth,
+    mockGoogleProvider: { providerId: "google.com", _mock: "google" },
+    mockGithubProvider: { providerId: "github.com", _mock: "github" },
+    signInWithPopup: vi.fn(),
+  };
+});
+
+vi.mock("../../lib/firebase", () => ({
+  auth: mockAuth,
+  googleProvider: mockGoogleProvider,
+  githubProvider: mockGithubProvider,
+  hasFirebaseConfig: true,
+  app: {},
+  db: null,
+  functions: null,
+}));
+
+vi.mock("firebase/auth", () => ({
+  createUserWithEmailAndPassword: vi.fn(),
+  onAuthStateChanged: vi.fn((_auth, callback) => {
+    callback(null);
+    return vi.fn();
+  }),
+  sendPasswordResetEmail: vi.fn(),
+  signInWithEmailAndPassword: vi.fn(),
+  signInWithPopup: (...args) => signInWithPopup(...args),
+  signOut: vi.fn(),
+  updateProfile: vi.fn(),
+  GoogleAuthProvider: vi.fn(),
+  GithubAuthProvider: vi.fn(),
+}));
+
+function renderSocialLogin(ui) {
+  return render(<AuthProvider>{ui}</AuthProvider>);
+}
+
+describe("SocialLoginButtons", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    signInWithPopup.mockResolvedValue(undefined);
+  });
+
+  it("renders social login heading and provider buttons", () => {
+    renderSocialLogin(<SocialLoginButtons />);
+    expect(screen.getByText("Or continue with")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Google" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "GitHub" })).toBeInTheDocument();
+  });
+
+  it("calls Firebase signInWithPopup with auth and Google provider and invokes onSuccess", async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    renderSocialLogin(<SocialLoginButtons onSuccess={onSuccess} />);
+
+    await user.click(screen.getByRole("button", { name: "Google" }));
+
+    expect(signInWithPopup).toHaveBeenCalledTimes(1);
+    expect(signInWithPopup).toHaveBeenCalledWith(mockAuth, mockGoogleProvider);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls Firebase signInWithPopup with auth and GitHub provider and invokes onSuccess", async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    renderSocialLogin(<SocialLoginButtons onSuccess={onSuccess} />);
+
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+
+    expect(signInWithPopup).toHaveBeenCalledTimes(1);
+    expect(signInWithPopup).toHaveBeenCalledWith(mockAuth, mockGithubProvider);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onSuccess when prop is omitted after successful sign-in", async () => {
+    const user = userEvent.setup();
+    renderSocialLogin(<SocialLoginButtons />);
+
+    await user.click(screen.getByRole("button", { name: "Google" }));
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+
+    expect(signInWithPopup).toHaveBeenCalledTimes(2);
+  });
+
+  it("logs and swallows errors when Google sign-in fails", async () => {
+    const user = userEvent.setup();
+    const err = new Error("popup blocked");
+    signInWithPopup.mockRejectedValueOnce(err);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onSuccess = vi.fn();
+
+    renderSocialLogin(<SocialLoginButtons onSuccess={onSuccess} />);
+    await user.click(screen.getByRole("button", { name: "Google" }));
+
+    expect(errorSpy).toHaveBeenCalledWith("Google sign-in failed", err);
+    expect(onSuccess).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("logs and swallows errors when GitHub sign-in fails", async () => {
+    const user = userEvent.setup();
+    const err = new Error("network");
+    signInWithPopup.mockRejectedValueOnce(err);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const onSuccess = vi.fn();
+
+    renderSocialLogin(<SocialLoginButtons onSuccess={onSuccess} />);
+    await user.click(screen.getByRole("button", { name: "GitHub" }));
+
+    expect(errorSpy).toHaveBeenCalledWith("GitHub sign-in failed", err);
+    expect(onSuccess).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit tests for `SocialLoginButtons.jsx` using Vitest and Testing Library. The component is rendered inside `AuthProvider` while `firebase/auth` (`signInWithPopup` and related exports) and `lib/firebase` (mock `auth`, Google/GitHub provider objects) are stubbed so social sign-in stays fully offline and deterministic.

## Coverage

- Renders copy and Google/GitHub buttons.
- Successful Google/GitHub clicks call `signInWithPopup` with the mocked auth instance and the correct provider; `onSuccess` runs when provided.
- Omits `onSuccess` when the prop is absent (branch coverage).
- Failed sign-in logs `console.error` and does not call `onSuccess`.

`npm run test:coverage` reports **100%** statements/branches/functions/lines for `SocialLoginButtons.jsx`.

## Merge / CI

This branch is merged with current `main`. Local verification matches GitHub Actions:

- `npm ci` (root) → `npm run ci` (Biome)
- `frontend`: `npm ci`, `npm run build`, `npm run test:coverage`
- `functions`: `npm ci`, `npm test`

## Verification

```bash
npm ci && npm run ci
cd frontend && npm ci && npm run build && npm run test:coverage
cd ../functions && npm ci && npm test
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-baa4e0ea-b7df-46af-bb75-f6a4be0653a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-baa4e0ea-b7df-46af-bb75-f6a4be0653a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

