### PR TITLE
test(frontend): Vitest unit tests for firebase bootstrap

### DIFF
--- a/frontend/src/lib/firebase.test.js
+++ b/frontend/src/lib/firebase.test.js
@@ -1,0 +1,294 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const m = vi.hoisted(() => {
+  const mockApp = { name: "mock-app" };
+  const mockAuth = { _auth: true };
+  const mockDb = { _db: true };
+  const mockFunctions = { _fn: true };
+
+  return {
+    mockApp,
+    mockAuth,
+    mockDb,
+    mockFunctions,
+    initializeApp: vi.fn(() => mockApp),
+    getApps: vi.fn(() => []),
+    getApp: vi.fn(() => mockApp),
+    connectAuthEmulator: vi.fn(),
+    connectFirestoreEmulator: vi.fn(),
+    connectFunctionsEmulator: vi.fn(),
+    getAuth: vi.fn(() => mockAuth),
+    getFirestore: vi.fn(() => mockDb),
+    getFunctions: vi.fn(() => mockFunctions),
+    setPersistence: vi.fn(() => Promise.resolve()),
+    browserLocalPersistence: "LOCAL",
+    GoogleAuthProvider: vi.fn(function GoogleAuthProvider() {
+      this.setCustomParameters = vi.fn();
+    }),
+    GithubAuthProvider: vi.fn(function GithubAuthProvider() {
+      this.setCustomParameters = vi.fn();
+    }),
+  };
+});
+
+vi.mock("firebase/app", () => ({
+  getApp: m.getApp,
+  getApps: m.getApps,
+  initializeApp: m.initializeApp,
+}));
+
+vi.mock("firebase/auth", () => ({
+  GithubAuthProvider: m.GithubAuthProvider,
+  GoogleAuthProvider: m.GoogleAuthProvider,
+  browserLocalPersistence: m.browserLocalPersistence,
+  connectAuthEmulator: m.connectAuthEmulator,
+  getAuth: m.getAuth,
+  setPersistence: m.setPersistence,
+}));
+
+vi.mock("firebase/firestore", () => ({
+  connectFirestoreEmulator: m.connectFirestoreEmulator,
+  getFirestore: m.getFirestore,
+}));
+
+vi.mock("firebase/functions", () => ({
+  connectFunctionsEmulator: m.connectFunctionsEmulator,
+  getFunctions: m.getFunctions,
+}));
+
+function stubValidFirebaseEnv() {
+  vi.stubEnv("VITE_FIREBASE_API_KEY", "key");
+  vi.stubEnv("VITE_FIREBASE_AUTH_DOMAIN", "example.test");
+  vi.stubEnv("VITE_FIREBASE_PROJECT_ID", "proj");
+  vi.stubEnv("VITE_FIREBASE_STORAGE_BUCKET", "bucket");
+  vi.stubEnv("VITE_FIREBASE_MESSAGING_SENDER_ID", "sender");
+  vi.stubEnv("VITE_FIREBASE_APP_ID", "app-id");
+  vi.stubEnv("VITE_FIREBASE_MEASUREMENT_ID", "G-XXXX");
+}
+
+function clearFirebaseEnv() {
+  for (const key of [
+    "VITE_FIREBASE_API_KEY",
+    "VITE_FIREBASE_AUTH_DOMAIN",
+    "VITE_FIREBASE_PROJECT_ID",
+    "VITE_FIREBASE_STORAGE_BUCKET",
+    "VITE_FIREBASE_MESSAGING_SENDER_ID",
+    "VITE_FIREBASE_APP_ID",
+    "VITE_FIREBASE_MEASUREMENT_ID",
+    "VITE_USE_EMULATORS",
+    "VITE_FIREBASE_AUTH_EMULATOR_URL",
+    "VITE_FIRESTORE_EMULATOR_HOST",
+    "VITE_FIRESTORE_EMULATOR_PORT",
+    "VITE_FUNCTIONS_EMULATOR_HOST",
+    "VITE_FUNCTIONS_EMULATOR_PORT",
+  ]) {
+    vi.stubEnv(key, "");
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("firebase module", () => {
+  let warnSpy;
+  let debugSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    m.initializeApp.mockClear().mockImplementation(() => m.mockApp);
+    m.getApps.mockClear().mockReturnValue([]);
+    m.getApp.mockClear().mockImplementation(() => m.mockApp);
+    m.connectAuthEmulator.mockClear().mockImplementation(() => {});
+    m.connectFirestoreEmulator.mockClear().mockImplementation(() => {});
+    m.connectFunctionsEmulator.mockClear().mockImplementation(() => {});
+    m.getAuth.mockClear().mockImplementation(() => m.mockAuth);
+    m.getFirestore.mockClear().mockImplementation(() => m.mockDb);
+    m.getFunctions.mockClear().mockImplementation(() => m.mockFunctions);
+    m.setPersistence.mockClear().mockImplementation(() => Promise.resolve());
+    m.GoogleAuthProvider.mockClear();
+    m.GithubAuthProvider.mockClear();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    debugSpy.mockRestore();
+    errorSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("warns and exports null services when config is incomplete", async () => {
+    clearFirebaseEnv();
+    const mod = await import("./firebase.js");
+
+    expect(mod.hasFirebaseConfig).toBe(false);
+    expect(mod.app).toBeNull();
+    expect(mod.auth).toBeNull();
+    expect(mod.db).toBeNull();
+    expect(mod.functions).toBeNull();
+    expect(mod.googleProvider).toBeNull();
+    expect(mod.githubProvider).toBeNull();
+    expect(m.initializeApp).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Firebase is not configured"));
+    expect(m.connectAuthEmulator).not.toHaveBeenCalled();
+  });
+
+  it("treats whitespace-only env values as missing config", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_FIREBASE_API_KEY", "   ");
+    const mod = await import("./firebase.js");
+
+    expect(mod.hasFirebaseConfig).toBe(false);
+    expect(mod.app).toBeNull();
+    expect(m.initializeApp).not.toHaveBeenCalled();
+  });
+
+  it("initializes the app when config is valid and no app exists yet", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "false");
+    m.getApps.mockReturnValue([]);
+
+    const mod = await import("./firebase.js");
+
+    expect(mod.hasFirebaseConfig).toBe(true);
+    expect(m.initializeApp).toHaveBeenCalledTimes(1);
+    expect(m.initializeApp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "key",
+        projectId: "proj",
+        appId: "app-id",
+      }),
+    );
+    expect(m.getApp).not.toHaveBeenCalled();
+    expect(mod.app).toBe(m.mockApp);
+    expect(m.getAuth).toHaveBeenCalledWith(m.mockApp);
+    expect(m.GoogleAuthProvider).toHaveBeenCalled();
+    expect(m.GithubAuthProvider).toHaveBeenCalled();
+  });
+
+  it("reuses an existing app via getApp when getApps is non-empty", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "false");
+    m.getApps.mockReturnValue([m.mockApp]);
+
+    const mod = await import("./firebase.js");
+
+    expect(mod.hasFirebaseConfig).toBe(true);
+    expect(m.getApp).toHaveBeenCalledTimes(1);
+    expect(m.initializeApp).not.toHaveBeenCalled();
+  });
+
+  it("connects emulators with defaults when VITE_USE_EMULATORS is true (case-insensitive)", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "TRUE");
+
+    await import("./firebase.js");
+
+    expect(m.connectAuthEmulator).toHaveBeenCalledWith(m.mockAuth, "http://127.0.0.1:9099", {
+      disableWarnings: true,
+    });
+    expect(m.connectFirestoreEmulator).toHaveBeenCalledWith(m.mockDb, "127.0.0.1", 8080);
+    expect(m.connectFunctionsEmulator).toHaveBeenCalledWith(m.mockFunctions, "127.0.0.1", 5001);
+  });
+
+  it("uses custom emulator host and port env overrides", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "true");
+    vi.stubEnv("VITE_FIREBASE_AUTH_EMULATOR_URL", "http://custom:9099");
+    vi.stubEnv("VITE_FIRESTORE_EMULATOR_HOST", "10.0.0.1");
+    vi.stubEnv("VITE_FIRESTORE_EMULATOR_PORT", "18080");
+    vi.stubEnv("VITE_FUNCTIONS_EMULATOR_HOST", "10.0.0.2");
+    vi.stubEnv("VITE_FUNCTIONS_EMULATOR_PORT", "15001");
+
+    await import("./firebase.js");
+
+    expect(m.connectAuthEmulator).toHaveBeenCalledWith(m.mockAuth, "http://custom:9099", {
+      disableWarnings: true,
+    });
+    expect(m.connectFirestoreEmulator).toHaveBeenCalledWith(m.mockDb, "10.0.0.1", 18080);
+    expect(m.connectFunctionsEmulator).toHaveBeenCalledWith(m.mockFunctions, "10.0.0.2", 15001);
+  });
+
+  it("logs debug when Auth emulator connection throws", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "true");
+    const err = new Error("auth already connected");
+    m.connectAuthEmulator.mockImplementation(() => {
+      throw err;
+    });
+
+    await import("./firebase.js");
+
+    expect(debugSpy).toHaveBeenCalledWith("Auth emulator connection skipped", err);
+    expect(m.connectFirestoreEmulator).toHaveBeenCalled();
+    expect(m.connectFunctionsEmulator).toHaveBeenCalled();
+  });
+
+  it("logs debug when Firestore emulator connection throws", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "true");
+    const err = new Error("firestore already connected");
+    m.connectFirestoreEmulator.mockImplementation(() => {
+      throw err;
+    });
+
+    await import("./firebase.js");
+
+    expect(debugSpy).toHaveBeenCalledWith("Firestore emulator connection skipped", err);
+  });
+
+  it("logs debug when Functions emulator connection throws", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "true");
+    const err = new Error("functions already connected");
+    m.connectFunctionsEmulator.mockImplementation(() => {
+      throw err;
+    });
+
+    await import("./firebase.js");
+
+    expect(debugSpy).toHaveBeenCalledWith("Functions emulator connection skipped", err);
+  });
+
+  it("logs error when setPersistence rejects", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "false");
+    const persistErr = new Error("persistence blocked");
+    m.setPersistence.mockImplementation(() => Promise.reject(persistErr));
+
+    await import("./firebase.js");
+    await flushMicrotasks();
+
+    expect(errorSpy).toHaveBeenCalledWith("Failed to set Firebase auth persistence", persistErr);
+  });
+
+  it("does not connect emulators when app services are missing", async () => {
+    clearFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "true");
+
+    await import("./firebase.js");
+
+    expect(m.connectAuthEmulator).not.toHaveBeenCalled();
+    expect(m.connectFirestoreEmulator).not.toHaveBeenCalled();
+    expect(m.connectFunctionsEmulator).not.toHaveBeenCalled();
+  });
+
+  it("sets OAuth provider custom parameters when auth exists", async () => {
+    stubValidFirebaseEnv();
+    vi.stubEnv("VITE_USE_EMULATORS", "false");
+
+    await import("./firebase.js");
+
+    const googleInstance = m.GoogleAuthProvider.mock.results[0]?.value;
+    const githubInstance = m.GithubAuthProvider.mock.results[0]?.value;
+    expect(googleInstance?.setCustomParameters).toHaveBeenCalledWith({ prompt: "select_account" });
+    expect(githubInstance?.setCustomParameters).toHaveBeenCalledWith({ allow_signup: "false" });
+  });
+});

--- a/frontend/src/pages/Account/components/TradesPanel.test.jsx
+++ b/frontend/src/pages/Account/components/TradesPanel.test.jsx
@@ -254,10 +254,7 @@ describe("TradesPanel", () => {
       await user.click(screen.getByRole("button", { name: "Mark completed" }));
 
       expect(alertSpy).toHaveBeenCalledWith("Network failure");
-      expect(errorSpy).toHaveBeenCalledWith(
-        "Failed to update trade status",
-        expect.any(Error),
-      );
+      expect(errorSpy).toHaveBeenCalledWith("Failed to update trade status", expect.any(Error));
     });
 
     it("alerts a generic message when the error has no message", async () => {
@@ -297,8 +294,12 @@ describe("TradesPanel", () => {
       expect(within(items[2]).getByText(/Card C/)).toBeInTheDocument();
 
       expect(within(items[0]).getByRole("button", { name: "Mark completed" })).toBeInTheDocument();
-      expect(within(items[1]).queryByRole("button", { name: "Mark completed" })).not.toBeInTheDocument();
-      expect(within(items[2]).queryByRole("button", { name: "Mark completed" })).not.toBeInTheDocument();
+      expect(
+        within(items[1]).queryByRole("button", { name: "Mark completed" }),
+      ).not.toBeInTheDocument();
+      expect(
+        within(items[2]).queryByRole("button", { name: "Mark completed" }),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/frontend/src/pages/Account/hooks/useMyTrades.test.js
+++ b/frontend/src/pages/Account/hooks/useMyTrades.test.js
@@ -1,4 +1,4 @@
-import { renderHook, act } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../../lib/firebase", () => ({ db: { _tag: "mock-firestore" } }));
@@ -130,8 +130,14 @@ describe("useMyTrades", () => {
       const onNext = mockOnSnapshot.mock.calls[0][1];
       const fakeSnap = {
         docs: [
-          { id: "trade-1", data: () => ({ status: "pending", participants: ["user-123", "user-456"] }) },
-          { id: "trade-2", data: () => ({ status: "complete", participants: ["user-123", "user-789"] }) },
+          {
+            id: "trade-1",
+            data: () => ({ status: "pending", participants: ["user-123", "user-456"] }),
+          },
+          {
+            id: "trade-2",
+            data: () => ({ status: "complete", participants: ["user-123", "user-789"] }),
+          },
         ],
       };
 

--- a/frontend/src/pages/Account/index.test.jsx
+++ b/frontend/src/pages/Account/index.test.jsx
@@ -16,9 +16,7 @@ vi.mock("../../components/Auth/AuthGuard", () => ({
 }));
 
 vi.mock("./components/TradesPanel", () => ({
-  default: ({ user }) => (
-    <div data-testid="trades-panel">TradesPanel:{user?.uid}</div>
-  ),
+  default: ({ user }) => <div data-testid="trades-panel">TradesPanel:{user?.uid}</div>,
 }));
 
 import AccountPage from "./index.jsx";
@@ -49,12 +47,8 @@ describe("AccountPage", () => {
 
   it("renders the page header and hint when authenticated", () => {
     renderAccountPage();
-    expect(
-      screen.getByRole("heading", { name: "Account Settings" }),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/keep your contact details up to date/i),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Account Settings" })).toBeInTheDocument();
+    expect(screen.getByText(/keep your contact details up to date/i)).toBeInTheDocument();
   });
 
   it("renders within an account-page section", () => {
@@ -74,9 +68,7 @@ describe("AccountPage", () => {
 
   it("renders the Profile overview heading when user exists", () => {
     renderAccountPage();
-    expect(
-      screen.getByRole("heading", { name: "Profile overview" }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Profile overview" })).toBeInTheDocument();
   });
 
   it("renders profile summary with Display name and Primary email labels", () => {
@@ -135,18 +127,10 @@ describe("AccountPage", () => {
 
     it("renders all form fields with correct placeholders", () => {
       renderAccountPage();
-      expect(
-        screen.getByPlaceholderText("Add a phone number"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByPlaceholderText("Street, city, state, ZIP"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByPlaceholderText("Add a backup email"),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByPlaceholderText("Optional additional backup email"),
-      ).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Add a phone number")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Street, city, state, ZIP")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Add a backup email")).toBeInTheDocument();
+      expect(screen.getByPlaceholderText("Optional additional backup email")).toBeInTheDocument();
     });
 
     it("renders form fields with correct labels", () => {
@@ -154,9 +138,7 @@ describe("AccountPage", () => {
       expect(screen.getByLabelText("Phone number")).toBeInTheDocument();
       expect(screen.getByLabelText("Mailing address")).toBeInTheDocument();
       expect(screen.getByLabelText("Backup email (primary)")).toBeInTheDocument();
-      expect(
-        screen.getByLabelText("Backup email (secondary)"),
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText("Backup email (secondary)")).toBeInTheDocument();
     });
 
     it("updates the phone number field on input", async () => {
@@ -197,32 +179,20 @@ describe("AccountPage", () => {
 
       await user.type(screen.getByLabelText("Phone number"), "555-1234");
       await user.type(screen.getByLabelText("Mailing address"), "123 Main St");
-      await user.type(
-        screen.getByLabelText("Backup email (primary)"),
-        "backup@example.com",
-      );
-      await user.type(
-        screen.getByLabelText("Backup email (secondary)"),
-        "alt@example.com",
-      );
+      await user.type(screen.getByLabelText("Backup email (primary)"), "backup@example.com");
+      await user.type(screen.getByLabelText("Backup email (secondary)"), "alt@example.com");
 
       expect(screen.getByLabelText("Phone number")).toHaveValue("555-1234");
       expect(screen.getByLabelText("Mailing address")).toHaveValue("123 Main St");
-      expect(screen.getByLabelText("Backup email (primary)")).toHaveValue(
-        "backup@example.com",
-      );
-      expect(screen.getByLabelText("Backup email (secondary)")).toHaveValue(
-        "alt@example.com",
-      );
+      expect(screen.getByLabelText("Backup email (primary)")).toHaveValue("backup@example.com");
+      expect(screen.getByLabelText("Backup email (secondary)")).toHaveValue("alt@example.com");
     });
 
     it('shows "Saved locally" feedback after form submission', async () => {
       const user = userEvent.setup();
       renderAccountPage();
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
-      expect(
-        screen.getByText("Saved locally — sync options coming soon."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Saved locally — sync options coming soon.")).toBeInTheDocument();
     });
 
     it("clears the saved feedback when a field is changed after submission", async () => {
@@ -230,9 +200,7 @@ describe("AccountPage", () => {
       renderAccountPage();
 
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
-      expect(
-        screen.getByText("Saved locally — sync options coming soon."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Saved locally — sync options coming soon.")).toBeInTheDocument();
 
       await user.type(screen.getByLabelText("Phone number"), "x");
       expect(
@@ -250,8 +218,7 @@ describe("AccountPage", () => {
     it("form submit does not navigate away (default prevented)", async () => {
       const user = userEvent.setup();
       renderAccountPage();
-      const form = screen.getByRole("button", { name: "Save contact info" })
-        .closest("form");
+      const form = screen.getByRole("button", { name: "Save contact info" }).closest("form");
       const submitSpy = vi.fn((e) => e.preventDefault());
       form.addEventListener("submit", submitSpy);
 
@@ -262,9 +229,7 @@ describe("AccountPage", () => {
     it("calls preventDefault on form submit event", async () => {
       const user = userEvent.setup();
       renderAccountPage();
-      const form = screen
-        .getByRole("button", { name: "Save contact info" })
-        .closest("form");
+      const form = screen.getByRole("button", { name: "Save contact info" }).closest("form");
       let submittedEvent;
       form.addEventListener("submit", (e) => {
         submittedEvent = e;
@@ -283,9 +248,7 @@ describe("AccountPage", () => {
       await user.type(screen.getByLabelText("Phone number"), "555-9999");
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
 
-      expect(
-        screen.getByText("Saved locally — sync options coming soon."),
-      ).toBeInTheDocument();
+      expect(screen.getByText("Saved locally — sync options coming soon.")).toBeInTheDocument();
       expect(screen.getByLabelText("Phone number")).toHaveValue("555-9999");
     });
   });
@@ -295,22 +258,14 @@ describe("AccountPage", () => {
   describe("notification preferences", () => {
     it("renders the notification preferences heading", () => {
       renderAccountPage();
-      expect(
-        screen.getByRole("heading", { name: "Notification preferences" }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole("heading", { name: "Notification preferences" })).toBeInTheDocument();
     });
 
     it("renders all notification option labels", () => {
       renderAccountPage();
-      expect(
-        screen.getByText(/email me when cards I need are offered/i),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/notify me about upcoming community events/i),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/alerts for direct trade messages/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/email me when cards I need are offered/i)).toBeInTheDocument();
+      expect(screen.getByText(/notify me about upcoming community events/i)).toBeInTheDocument();
+      expect(screen.getByText(/alerts for direct trade messages/i)).toBeInTheDocument();
     });
 
     it("has all notification checkboxes in a disabled fieldset", () => {

--- a/frontend/src/pages/CollectibleDetail/components/CreateListingForm.test.jsx
+++ b/frontend/src/pages/CollectibleDetail/components/CreateListingForm.test.jsx
@@ -5,584 +5,567 @@ import CreateListingForm, { dollarsToCents } from "./CreateListingForm.jsx";
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", () => ({
-	useNavigate: () => mockNavigate,
+  useNavigate: () => mockNavigate,
 }));
 
 const mockCreateListing = vi.fn();
 vi.mock("../../../lib/marketplace/listings", () => ({
-	createListing: (...args) => mockCreateListing(...args),
+  createListing: (...args) => mockCreateListing(...args),
 }));
 
 let mockUser = null;
 vi.mock("../../../contexts/AuthContext", () => ({
-	useAuth: () => ({ user: mockUser }),
+  useAuth: () => ({ user: mockUser }),
 }));
 
 function renderForm(props = {}) {
-	const defaults = { collectibleId: "card-42" };
-	return render(<CreateListingForm {...defaults} {...props} />);
+  const defaults = { collectibleId: "card-42" };
+  return render(<CreateListingForm {...defaults} {...props} />);
 }
 
 describe("dollarsToCents", () => {
-	it("returns null for empty string", () => {
-		expect(dollarsToCents("")).toBeNull();
-	});
+  it("returns null for empty string", () => {
+    expect(dollarsToCents("")).toBeNull();
+  });
 
-	it("returns null for whitespace-only string", () => {
-		expect(dollarsToCents("   ")).toBeNull();
-		expect(dollarsToCents("\t\n")).toBeNull();
-	});
+  it("returns null for whitespace-only string", () => {
+    expect(dollarsToCents("   ")).toBeNull();
+    expect(dollarsToCents("\t\n")).toBeNull();
+  });
 
-	it("returns null for null or undefined", () => {
-		expect(dollarsToCents(null)).toBeNull();
-		expect(dollarsToCents(undefined)).toBeNull();
-	});
+  it("returns null for null or undefined", () => {
+    expect(dollarsToCents(null)).toBeNull();
+    expect(dollarsToCents(undefined)).toBeNull();
+  });
 
-	it("returns null for zero", () => {
-		expect(dollarsToCents("0")).toBeNull();
-		expect(dollarsToCents(0)).toBeNull();
-	});
+  it("returns null for zero", () => {
+    expect(dollarsToCents("0")).toBeNull();
+    expect(dollarsToCents(0)).toBeNull();
+  });
 
-	it("returns null for negative values", () => {
-		expect(dollarsToCents("-5")).toBeNull();
-		expect(dollarsToCents(-10)).toBeNull();
-	});
+  it("returns null for negative values", () => {
+    expect(dollarsToCents("-5")).toBeNull();
+    expect(dollarsToCents(-10)).toBeNull();
+  });
 
-	it("returns null for non-numeric strings", () => {
-		expect(dollarsToCents("abc")).toBeNull();
-		expect(dollarsToCents("$10")).toBeNull();
-	});
+  it("returns null for non-numeric strings", () => {
+    expect(dollarsToCents("abc")).toBeNull();
+    expect(dollarsToCents("$10")).toBeNull();
+  });
 
-	it("returns null for NaN", () => {
-		expect(dollarsToCents(NaN)).toBeNull();
-	});
+  it("returns null for NaN", () => {
+    expect(dollarsToCents(NaN)).toBeNull();
+  });
 
-	it("returns null for Infinity", () => {
-		expect(dollarsToCents("Infinity")).toBeNull();
-	});
+  it("returns null for Infinity", () => {
+    expect(dollarsToCents("Infinity")).toBeNull();
+  });
 
-	it("converts whole dollars to cents", () => {
-		expect(dollarsToCents("10")).toBe(1000);
-		expect(dollarsToCents(25)).toBe(2500);
-	});
+  it("converts whole dollars to cents", () => {
+    expect(dollarsToCents("10")).toBe(1000);
+    expect(dollarsToCents(25)).toBe(2500);
+  });
 
-	it("converts decimal amounts to cents", () => {
-		expect(dollarsToCents("25.50")).toBe(2550);
-		expect(dollarsToCents("0.01")).toBe(1);
-	});
+  it("converts decimal amounts to cents", () => {
+    expect(dollarsToCents("25.50")).toBe(2550);
+    expect(dollarsToCents("0.01")).toBe(1);
+  });
 
-	it("rounds fractional cents", () => {
-		expect(dollarsToCents("10.999")).toBe(1100);
-		expect(dollarsToCents("10.004")).toBe(1000);
-	});
+  it("rounds fractional cents", () => {
+    expect(dollarsToCents("10.999")).toBe(1100);
+    expect(dollarsToCents("10.004")).toBe(1000);
+  });
 
-	it("trims surrounding whitespace", () => {
-		expect(dollarsToCents("  10  ")).toBe(1000);
-	});
+  it("trims surrounding whitespace", () => {
+    expect(dollarsToCents("  10  ")).toBe(1000);
+  });
 });
 
 describe("CreateListingForm", () => {
-	beforeEach(() => {
-		vi.clearAllMocks();
-		mockCreateListing.mockReset();
-		mockUser = null;
-	});
-
-	describe("rendering", () => {
-		it("renders a type select, price input, and submit button", () => {
-			renderForm();
-			expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
-			expect(screen.getByLabelText(/price/i)).toBeInTheDocument();
-			expect(screen.getByRole("button")).toBeInTheDocument();
-		});
-
-		it("renders a form with create-listing className", () => {
-			renderForm();
-			const form = document.querySelector("form.create-listing");
-			expect(form).toBeTruthy();
-			expect(form).toHaveClass("create-listing");
-		});
-
-		it("price input has correct attributes", () => {
-			renderForm();
-			const input = screen.getByPlaceholderText("10.00");
-			expect(input).toHaveAttribute("type", "number");
-			expect(input).toHaveAttribute("min", "0");
-			expect(input).toHaveAttribute("step", "0.01");
-			expect(input).toHaveAttribute("inputMode", "decimal");
-		});
-
-		it("shows 'Sign in to create listing' when signed out", () => {
-			renderForm();
-			expect(
-				screen.getByRole("button", { name: /sign in to create listing/i }),
-			).toBeInTheDocument();
-		});
-
-		it("shows 'Create listing' when signed in", () => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-			renderForm();
-			expect(
-				screen.getByRole("button", { name: "Create listing" }),
-			).toBeInTheDocument();
-		});
-
-		it("defaults type to BID", () => {
-			renderForm();
-			expect(screen.getByLabelText(/type/i)).toHaveValue("BID");
-		});
-
-		it("defaults price to empty", () => {
-			renderForm();
-			expect(screen.getByPlaceholderText("10.00")).toHaveValue(null);
-		});
-
-		it("renders both type options", () => {
-			renderForm();
-			const options = screen.getAllByRole("option");
-			expect(options).toHaveLength(2);
-			expect(options[0]).toHaveTextContent("Buy (Bid)");
-			expect(options[1]).toHaveTextContent("Sell (Ask)");
-		});
-
-		it("renders the quantity disclaimer message", () => {
-			renderForm();
-			expect(
-				screen.getByText(/quantity is fixed to 1/i),
-			).toBeInTheDocument();
-		});
-	});
-
-	describe("type selection", () => {
-		it("can switch type to ASK", async () => {
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
-			expect(screen.getByLabelText(/type/i)).toHaveValue("ASK");
-		});
-
-		it("can switch back to BID", async () => {
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
-			await user.selectOptions(screen.getByLabelText(/type/i), "BID");
-			expect(screen.getByLabelText(/type/i)).toHaveValue("BID");
-		});
-	});
-
-	describe("submit when unauthenticated", () => {
-		it("navigates to login with return path using collectibleId", async () => {
-			mockUser = null;
-			const user = userEvent.setup();
-			renderForm({ collectibleId: "card-99" });
-
-			await user.click(screen.getByRole("button"));
-			expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
-				state: { from: { pathname: "/collectibles/card-99" } },
-			});
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("navigates to login with cardId fallback when collectibleId is absent", async () => {
-			mockUser = null;
-			const user = userEvent.setup();
-			renderForm({ collectibleId: undefined, cardId: "fallback-id" });
-
-			await user.click(screen.getByRole("button"));
-			expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
-				state: { from: { pathname: "/collectibles/fallback-id" } },
-			});
-		});
-	});
-
-	describe("dollarsToCents validation (via form submission)", () => {
-		beforeEach(() => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-		});
-
-		it("rejects empty price", async () => {
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("rejects zero", async () => {
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "0");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("rejects negative values", async () => {
-			const user = userEvent.setup();
-			renderForm();
-
-			// type="number" often blocks "-" in user-event; set value directly
-			fireEvent.change(screen.getByPlaceholderText("10.00"), {
-				target: { value: "-5" },
-			});
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("converts a whole-dollar amount to cents", async () => {
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "25");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ priceCents: 2500 }),
-				);
-			});
-		});
-
-		it("converts a decimal amount to cents", async () => {
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "25.50");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ priceCents: 2550 }),
-				);
-			});
-		});
-
-		it("rounds fractional cents", async () => {
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10.999");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ priceCents: 1100 }),
-				);
-			});
-		});
-
-		it("rejects whitespace-only price", async () => {
-			const user = userEvent.setup();
-			renderForm();
-			const priceInput = screen.getByPlaceholderText("10.00");
-
-			fireEvent.change(priceInput, { target: { value: "   " } });
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("rejects non-numeric price", async () => {
-			const user = userEvent.setup();
-			renderForm();
-			const priceInput = screen.getByPlaceholderText("10.00");
-
-			fireEvent.change(priceInput, { target: { value: "abc" } });
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-			expect(mockCreateListing).not.toHaveBeenCalled();
-		});
-
-		it("accepts minimum valid price (0.01)", async () => {
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "0.01");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ priceCents: 1 }),
-				);
-			});
-		});
-	});
-
-	describe("successful listing creation", () => {
-		it("calls createListing with the full BID payload", async () => {
-			mockUser = { uid: "u1", displayName: "Alice", email: "a@b.com" };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm({ collectibleId: "card-42" });
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith({
-					type: "BID",
-					cardId: "card-42",
-					priceCents: 1000,
-					currency: "USD",
-					quantity: 1,
-					createdByUid: "u1",
-					createdByDisplayName: "Alice",
-				});
-			});
-		});
-
-		it("sends ASK type when selected", async () => {
-			mockUser = { uid: "u1", displayName: "Bob", email: "b@b.com" };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
-			await user.type(screen.getByPlaceholderText("10.00"), "99.99");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ type: "ASK", priceCents: 9999 }),
-				);
-			});
-		});
-
-		it("falls back to email when displayName is falsy", async () => {
-			mockUser = { uid: "u2", displayName: "", email: "test@example.com" };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "1");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({
-						createdByDisplayName: "test@example.com",
-					}),
-				);
-			});
-		});
-
-		it("passes falsy value for createdByDisplayName when both displayName and email are falsy", async () => {
-			mockUser = { uid: "u3", displayName: null, email: null };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "5");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				const call = mockCreateListing.mock.calls[0][0];
-				expect(call.createdByUid).toBe("u3");
-				expect(call.createdByDisplayName).toBeFalsy();
-			});
-		});
-
-		it("resets the price input after success", async () => {
-			mockUser = { uid: "u1", displayName: "A", email: "a@b.com" };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			const priceInput = screen.getByPlaceholderText("10.00");
-			await user.type(priceInput, "15");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(priceInput).toHaveValue(null);
-			});
-		});
-	});
-
-	describe("failed listing creation", () => {
-		beforeEach(() => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-			vi.spyOn(console, "error").mockImplementation(() => {});
-		});
-
-		it("shows an error message on API failure", async () => {
-			mockCreateListing.mockRejectedValueOnce(new Error("network"));
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			expect(
-				await screen.findByText("Failed to create listing."),
-			).toBeInTheDocument();
-		});
-
-		it("logs the error to the console", async () => {
-			const err = new Error("boom");
-			mockCreateListing.mockRejectedValueOnce(err);
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(console.error).toHaveBeenCalledWith("Failed to create listing", err);
-			});
-		});
-
-		it("re-enables the form after failure", async () => {
-			mockCreateListing.mockRejectedValueOnce(new Error("boom"));
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(
-					screen.getByRole("button", { name: "Create listing" }),
-				).toBeEnabled();
-				expect(screen.getByLabelText(/type/i)).toBeEnabled();
-				expect(screen.getByPlaceholderText("10.00")).toBeEnabled();
-			});
-		});
-	});
-
-	describe("error clearing", () => {
-		it("clears a previous validation error on the next submit", async () => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-			mockCreateListing.mockResolvedValueOnce({});
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "5");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(
-					screen.queryByText("Enter a valid price."),
-				).not.toBeInTheDocument();
-			});
-		});
-
-		it("clears a previous API error on the next submit attempt", async () => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-			vi.spyOn(console, "error").mockImplementation(() => {});
-			mockCreateListing.mockRejectedValueOnce(new Error("fail"));
-			const user = userEvent.setup();
-			renderForm();
-
-			const priceInput = screen.getByPlaceholderText("10.00");
-			await user.type(priceInput, "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			expect(
-				await screen.findByText("Failed to create listing."),
-			).toBeInTheDocument();
-
-			mockCreateListing.mockResolvedValueOnce({});
-			// Avoid appending to existing "10" (would become "1010")
-			await user.clear(priceInput);
-			await user.type(priceInput, "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-			await waitFor(() => {
-				expect(
-					screen.queryByText("Failed to create listing."),
-				).not.toBeInTheDocument();
-			});
-		});
-	});
-
-	describe("submitting state", () => {
-		it("disables all inputs and the button while the request is pending", async () => {
-			mockUser = { uid: "u1", email: "a@b.com" };
-			let resolveCreate;
-			mockCreateListing.mockImplementation(
-				() => new Promise((resolve) => { resolveCreate = resolve; }),
-			);
-			const user = userEvent.setup();
-			renderForm();
-
-			await user.type(screen.getByPlaceholderText("10.00"), "10");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(
-					screen.getByRole("button", { name: "Create listing" }),
-				).toBeDisabled();
-				expect(screen.getByLabelText(/type/i)).toBeDisabled();
-				expect(screen.getByPlaceholderText("10.00")).toBeDisabled();
-			});
-
-			resolveCreate({});
-			await waitFor(() => {
-				expect(
-					screen.getByRole("button", { name: "Create listing" }),
-				).toBeEnabled();
-			});
-		});
-	});
-
-	describe("prop handling (collectibleId vs cardId)", () => {
-		beforeEach(() => {
-			mockUser = { uid: "u1", displayName: "A", email: "a@b.com" };
-			mockCreateListing.mockResolvedValue({});
-		});
-
-		it("prefers collectibleId over cardId", async () => {
-			const user = userEvent.setup();
-			renderForm({ collectibleId: "preferred", cardId: "fallback" });
-
-			await user.type(screen.getByPlaceholderText("10.00"), "5");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ cardId: "preferred" }),
-				);
-			});
-		});
-
-		it("uses cardId when collectibleId is undefined", async () => {
-			const user = userEvent.setup();
-			renderForm({ collectibleId: undefined, cardId: "fallback-id" });
-
-			await user.type(screen.getByPlaceholderText("10.00"), "5");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ cardId: "fallback-id" }),
-				);
-			});
-		});
-
-		it("uses cardId when collectibleId is null", async () => {
-			const user = userEvent.setup();
-			renderForm({ collectibleId: null, cardId: "null-fallback" });
-
-			await user.type(screen.getByPlaceholderText("10.00"), "5");
-			await user.click(screen.getByRole("button", { name: "Create listing" }));
-
-			await waitFor(() => {
-				expect(mockCreateListing).toHaveBeenCalledWith(
-					expect.objectContaining({ cardId: "null-fallback" }),
-				);
-			});
-		});
-	});
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateListing.mockReset();
+    mockUser = null;
+  });
+
+  describe("rendering", () => {
+    it("renders a type select, price input, and submit button", () => {
+      renderForm();
+      expect(screen.getByLabelText(/type/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/price/i)).toBeInTheDocument();
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    it("renders a form with create-listing className", () => {
+      renderForm();
+      const form = document.querySelector("form.create-listing");
+      expect(form).toBeTruthy();
+      expect(form).toHaveClass("create-listing");
+    });
+
+    it("price input has correct attributes", () => {
+      renderForm();
+      const input = screen.getByPlaceholderText("10.00");
+      expect(input).toHaveAttribute("type", "number");
+      expect(input).toHaveAttribute("min", "0");
+      expect(input).toHaveAttribute("step", "0.01");
+      expect(input).toHaveAttribute("inputMode", "decimal");
+    });
+
+    it("shows 'Sign in to create listing' when signed out", () => {
+      renderForm();
+      expect(
+        screen.getByRole("button", { name: /sign in to create listing/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows 'Create listing' when signed in", () => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+      renderForm();
+      expect(screen.getByRole("button", { name: "Create listing" })).toBeInTheDocument();
+    });
+
+    it("defaults type to BID", () => {
+      renderForm();
+      expect(screen.getByLabelText(/type/i)).toHaveValue("BID");
+    });
+
+    it("defaults price to empty", () => {
+      renderForm();
+      expect(screen.getByPlaceholderText("10.00")).toHaveValue(null);
+    });
+
+    it("renders both type options", () => {
+      renderForm();
+      const options = screen.getAllByRole("option");
+      expect(options).toHaveLength(2);
+      expect(options[0]).toHaveTextContent("Buy (Bid)");
+      expect(options[1]).toHaveTextContent("Sell (Ask)");
+    });
+
+    it("renders the quantity disclaimer message", () => {
+      renderForm();
+      expect(screen.getByText(/quantity is fixed to 1/i)).toBeInTheDocument();
+    });
+  });
+
+  describe("type selection", () => {
+    it("can switch type to ASK", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
+      expect(screen.getByLabelText(/type/i)).toHaveValue("ASK");
+    });
+
+    it("can switch back to BID", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
+      await user.selectOptions(screen.getByLabelText(/type/i), "BID");
+      expect(screen.getByLabelText(/type/i)).toHaveValue("BID");
+    });
+  });
+
+  describe("submit when unauthenticated", () => {
+    it("navigates to login with return path using collectibleId", async () => {
+      mockUser = null;
+      const user = userEvent.setup();
+      renderForm({ collectibleId: "card-99" });
+
+      await user.click(screen.getByRole("button"));
+      expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
+        state: { from: { pathname: "/collectibles/card-99" } },
+      });
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("navigates to login with cardId fallback when collectibleId is absent", async () => {
+      mockUser = null;
+      const user = userEvent.setup();
+      renderForm({ collectibleId: undefined, cardId: "fallback-id" });
+
+      await user.click(screen.getByRole("button"));
+      expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
+        state: { from: { pathname: "/collectibles/fallback-id" } },
+      });
+    });
+  });
+
+  describe("dollarsToCents validation (via form submission)", () => {
+    beforeEach(() => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+    });
+
+    it("rejects empty price", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("rejects zero", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "0");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("rejects negative values", async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      // type="number" often blocks "-" in user-event; set value directly
+      fireEvent.change(screen.getByPlaceholderText("10.00"), {
+        target: { value: "-5" },
+      });
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("converts a whole-dollar amount to cents", async () => {
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "25");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ priceCents: 2500 }),
+        );
+      });
+    });
+
+    it("converts a decimal amount to cents", async () => {
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "25.50");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ priceCents: 2550 }),
+        );
+      });
+    });
+
+    it("rounds fractional cents", async () => {
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10.999");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ priceCents: 1100 }),
+        );
+      });
+    });
+
+    it("rejects whitespace-only price", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      const priceInput = screen.getByPlaceholderText("10.00");
+
+      fireEvent.change(priceInput, { target: { value: "   " } });
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("rejects non-numeric price", async () => {
+      const user = userEvent.setup();
+      renderForm();
+      const priceInput = screen.getByPlaceholderText("10.00");
+
+      fireEvent.change(priceInput, { target: { value: "abc" } });
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+      expect(mockCreateListing).not.toHaveBeenCalled();
+    });
+
+    it("accepts minimum valid price (0.01)", async () => {
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "0.01");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(expect.objectContaining({ priceCents: 1 }));
+      });
+    });
+  });
+
+  describe("successful listing creation", () => {
+    it("calls createListing with the full BID payload", async () => {
+      mockUser = { uid: "u1", displayName: "Alice", email: "a@b.com" };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm({ collectibleId: "card-42" });
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith({
+          type: "BID",
+          cardId: "card-42",
+          priceCents: 1000,
+          currency: "USD",
+          quantity: 1,
+          createdByUid: "u1",
+          createdByDisplayName: "Alice",
+        });
+      });
+    });
+
+    it("sends ASK type when selected", async () => {
+      mockUser = { uid: "u1", displayName: "Bob", email: "b@b.com" };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.selectOptions(screen.getByLabelText(/type/i), "ASK");
+      await user.type(screen.getByPlaceholderText("10.00"), "99.99");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ type: "ASK", priceCents: 9999 }),
+        );
+      });
+    });
+
+    it("falls back to email when displayName is falsy", async () => {
+      mockUser = { uid: "u2", displayName: "", email: "test@example.com" };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "1");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({
+            createdByDisplayName: "test@example.com",
+          }),
+        );
+      });
+    });
+
+    it("passes falsy value for createdByDisplayName when both displayName and email are falsy", async () => {
+      mockUser = { uid: "u3", displayName: null, email: null };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "5");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        const call = mockCreateListing.mock.calls[0][0];
+        expect(call.createdByUid).toBe("u3");
+        expect(call.createdByDisplayName).toBeFalsy();
+      });
+    });
+
+    it("resets the price input after success", async () => {
+      mockUser = { uid: "u1", displayName: "A", email: "a@b.com" };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      const priceInput = screen.getByPlaceholderText("10.00");
+      await user.type(priceInput, "15");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(priceInput).toHaveValue(null);
+      });
+    });
+  });
+
+  describe("failed listing creation", () => {
+    beforeEach(() => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+      vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("shows an error message on API failure", async () => {
+      mockCreateListing.mockRejectedValueOnce(new Error("network"));
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      expect(await screen.findByText("Failed to create listing.")).toBeInTheDocument();
+    });
+
+    it("logs the error to the console", async () => {
+      const err = new Error("boom");
+      mockCreateListing.mockRejectedValueOnce(err);
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(console.error).toHaveBeenCalledWith("Failed to create listing", err);
+      });
+    });
+
+    it("re-enables the form after failure", async () => {
+      mockCreateListing.mockRejectedValueOnce(new Error("boom"));
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Create listing" })).toBeEnabled();
+        expect(screen.getByLabelText(/type/i)).toBeEnabled();
+        expect(screen.getByPlaceholderText("10.00")).toBeEnabled();
+      });
+    });
+  });
+
+  describe("error clearing", () => {
+    it("clears a previous validation error on the next submit", async () => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+      mockCreateListing.mockResolvedValueOnce({});
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      expect(screen.getByText("Enter a valid price.")).toBeInTheDocument();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "5");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(screen.queryByText("Enter a valid price.")).not.toBeInTheDocument();
+      });
+    });
+
+    it("clears a previous API error on the next submit attempt", async () => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+      vi.spyOn(console, "error").mockImplementation(() => {});
+      mockCreateListing.mockRejectedValueOnce(new Error("fail"));
+      const user = userEvent.setup();
+      renderForm();
+
+      const priceInput = screen.getByPlaceholderText("10.00");
+      await user.type(priceInput, "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      expect(await screen.findByText("Failed to create listing.")).toBeInTheDocument();
+
+      mockCreateListing.mockResolvedValueOnce({});
+      // Avoid appending to existing "10" (would become "1010")
+      await user.clear(priceInput);
+      await user.type(priceInput, "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+      await waitFor(() => {
+        expect(screen.queryByText("Failed to create listing.")).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("submitting state", () => {
+    it("disables all inputs and the button while the request is pending", async () => {
+      mockUser = { uid: "u1", email: "a@b.com" };
+      let resolveCreate;
+      mockCreateListing.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolveCreate = resolve;
+          }),
+      );
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.type(screen.getByPlaceholderText("10.00"), "10");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Create listing" })).toBeDisabled();
+        expect(screen.getByLabelText(/type/i)).toBeDisabled();
+        expect(screen.getByPlaceholderText("10.00")).toBeDisabled();
+      });
+
+      resolveCreate({});
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Create listing" })).toBeEnabled();
+      });
+    });
+  });
+
+  describe("prop handling (collectibleId vs cardId)", () => {
+    beforeEach(() => {
+      mockUser = { uid: "u1", displayName: "A", email: "a@b.com" };
+      mockCreateListing.mockResolvedValue({});
+    });
+
+    it("prefers collectibleId over cardId", async () => {
+      const user = userEvent.setup();
+      renderForm({ collectibleId: "preferred", cardId: "fallback" });
+
+      await user.type(screen.getByPlaceholderText("10.00"), "5");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ cardId: "preferred" }),
+        );
+      });
+    });
+
+    it("uses cardId when collectibleId is undefined", async () => {
+      const user = userEvent.setup();
+      renderForm({ collectibleId: undefined, cardId: "fallback-id" });
+
+      await user.type(screen.getByPlaceholderText("10.00"), "5");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ cardId: "fallback-id" }),
+        );
+      });
+    });
+
+    it("uses cardId when collectibleId is null", async () => {
+      const user = userEvent.setup();
+      renderForm({ collectibleId: null, cardId: "null-fallback" });
+
+      await user.type(screen.getByPlaceholderText("10.00"), "5");
+      await user.click(screen.getByRole("button", { name: "Create listing" }));
+
+      await waitFor(() => {
+        expect(mockCreateListing).toHaveBeenCalledWith(
+          expect.objectContaining({ cardId: "null-fallback" }),
+        );
+      });
+    });
+  });
 });

--- a/frontend/src/pages/CollectibleDetail/hooks/useCollectibleCollectionEntry.test.js
+++ b/frontend/src/pages/CollectibleDetail/hooks/useCollectibleCollectionEntry.test.js
@@ -61,9 +61,7 @@ describe("useCollectibleCollectionEntry", () => {
     });
 
     it("returns entry=null, loading=false, error=null for null ownerUid", () => {
-      const { result } = renderHook(() =>
-        useCollectibleCollectionEntry(null, "LT24-ELS-01", null),
-      );
+      const { result } = renderHook(() => useCollectibleCollectionEntry(null, "LT24-ELS-01", null));
 
       expect(result.current.entry).toBe(null);
       expect(result.current.loading).toBe(false);
@@ -71,9 +69,7 @@ describe("useCollectibleCollectionEntry", () => {
     });
 
     it("returns entry=null, loading=false, error=null for empty string ownerUid", () => {
-      const { result } = renderHook(() =>
-        useCollectibleCollectionEntry("", "LT24-ELS-01", null),
-      );
+      const { result } = renderHook(() => useCollectibleCollectionEntry("", "LT24-ELS-01", null));
 
       expect(result.current.entry).toBe(null);
       expect(result.current.loading).toBe(false);
@@ -88,9 +84,7 @@ describe("useCollectibleCollectionEntry", () => {
 
   describe("when neither collectibleId nor skuId is provided", () => {
     it("returns entry=null, loading=false when both are null/undefined", () => {
-      const { result } = renderHook(() =>
-        useCollectibleCollectionEntry("user-123", null, null),
-      );
+      const { result } = renderHook(() => useCollectibleCollectionEntry("user-123", null, null));
 
       expect(result.current.entry).toBe(null);
       expect(result.current.loading).toBe(false);
@@ -231,9 +225,7 @@ describe("useCollectibleCollectionEntry", () => {
         mockGetFinishesForCard.mockReturnValue(["DUN"]);
         mockToSkuId.mockReturnValue("LT24-ELS-01-DUN");
 
-        renderHook(() =>
-          useCollectibleCollectionEntry("user-123", "LT24-ELS-01", null),
-        );
+        renderHook(() => useCollectibleCollectionEntry("user-123", "LT24-ELS-01", null));
 
         expect(mockGetFinishesForCard).toHaveBeenCalledWith("LT24-ELS-01");
         expect(mockToSkuId).toHaveBeenCalledWith("LT24-ELS-01", "DUN");
@@ -274,13 +266,9 @@ describe("useCollectibleCollectionEntry", () => {
     describe("collectible has multiple finishes", () => {
       it("builds query with skuId 'in' array", () => {
         mockGetFinishesForCard.mockReturnValue(["DUN", "FOIL"]);
-        mockToSkuId
-          .mockReturnValueOnce("LT24-ELS-01-DUN")
-          .mockReturnValueOnce("LT24-ELS-01-FOIL");
+        mockToSkuId.mockReturnValueOnce("LT24-ELS-01-DUN").mockReturnValueOnce("LT24-ELS-01-FOIL");
 
-        renderHook(() =>
-          useCollectibleCollectionEntry("user-123", "LT24-ELS-01", null),
-        );
+        renderHook(() => useCollectibleCollectionEntry("user-123", "LT24-ELS-01", null));
 
         expect(mockToSkuId).toHaveBeenCalledWith("LT24-ELS-01", "DUN");
         expect(mockToSkuId).toHaveBeenCalledWith("LT24-ELS-01", "FOIL");
@@ -292,9 +280,7 @@ describe("useCollectibleCollectionEntry", () => {
 
       it("on success: sets entry from first doc", () => {
         mockGetFinishesForCard.mockReturnValue(["DUN", "FOIL"]);
-        mockToSkuId
-          .mockReturnValueOnce("LT24-ELS-01-DUN")
-          .mockReturnValueOnce("LT24-ELS-01-FOIL");
+        mockToSkuId.mockReturnValueOnce("LT24-ELS-01-DUN").mockReturnValueOnce("LT24-ELS-01-FOIL");
 
         const { result } = renderHook(() =>
           useCollectibleCollectionEntry("user-123", "LT24-ELS-01", null),
@@ -404,8 +390,7 @@ describe("useCollectibleCollectionEntry", () => {
       mockToSkuId.mockReturnValueOnce("LT24-ELS-01-DUN").mockReturnValueOnce("LT24-WOK-01-FOIL");
 
       const { rerender } = renderHook(
-        ({ collectibleId }) =>
-          useCollectibleCollectionEntry("user-123", collectibleId, null),
+        ({ collectibleId }) => useCollectibleCollectionEntry("user-123", collectibleId, null),
         { initialProps: { collectibleId: "LT24-ELS-01" } },
       );
 
@@ -459,9 +444,7 @@ describe("useCollectibleCollectionEntry", () => {
 
   describe("skuId takes precedence over collectibleId", () => {
     it("when both skuId and collectibleId are provided, uses skuId path", () => {
-      renderHook(() =>
-        useCollectibleCollectionEntry("user-123", "LT24-ELS-01", "LT24-ELS-01-DUN"),
-      );
+      renderHook(() => useCollectibleCollectionEntry("user-123", "LT24-ELS-01", "LT24-ELS-01-DUN"));
 
       expect(mockGetFinishesForCard).not.toHaveBeenCalled();
       expect(mockWhere).toHaveBeenCalledWith("skuId", "==", "LT24-ELS-01-DUN");

--- a/frontend/src/pages/CollectibleDetail/index.test.jsx
+++ b/frontend/src/pages/CollectibleDetail/index.test.jsx
@@ -33,21 +33,15 @@ vi.mock("./hooks/useCollectibleCollectionEntry", () => ({
 }));
 
 vi.mock("../Collectibles/components/AddToCollectionButton", () => ({
-  default: ({ collectible }) => (
-    <div data-testid="add-to-collection">{collectible?.id}</div>
-  ),
+  default: ({ collectible }) => <div data-testid="add-to-collection">{collectible?.id}</div>,
 }));
 
 vi.mock("./components/CollectibleListingsPanel", () => ({
-  default: ({ collectibleId }) => (
-    <div data-testid="listings-panel">{collectibleId}</div>
-  ),
+  default: ({ collectibleId }) => <div data-testid="listings-panel">{collectibleId}</div>,
 }));
 
 vi.mock("./components/CreateListingForm", () => ({
-  default: ({ collectibleId }) => (
-    <div data-testid="create-listing-form">{collectibleId}</div>
-  ),
+  default: ({ collectibleId }) => <div data-testid="create-listing-form">{collectibleId}</div>,
 }));
 
 /* ------------------------------------------------------------------ */
@@ -197,12 +191,17 @@ describe("CollectibleDetailPage – detail view (no user)", () => {
 describe("CollectibleDetailPage – SKU route", () => {
   it("prefers skuRecord.card when both collectibleId and skuId are present", () => {
     const skuCard = { ...CARD, displayName: "SKU Variant" };
-    setDefaults({ skuRecord: { skuId: "LT24-ELS-01-DUN", cardId: "LT24-ELS-01", finish: "DUN", card: skuCard } });
+    setDefaults({
+      skuRecord: { skuId: "LT24-ELS-01-DUN", cardId: "LT24-ELS-01", finish: "DUN", card: skuCard },
+    });
 
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -211,12 +210,18 @@ describe("CollectibleDetailPage – SKU route", () => {
   });
 
   it("shows SKU ID in the detail stats when skuId param is present", () => {
-    setDefaults({ card: CARD, skuRecord: { skuId: "LT24-ELS-01-DUN", cardId: "LT24-ELS-01", finish: "DUN", card: CARD } });
+    setDefaults({
+      card: CARD,
+      skuRecord: { skuId: "LT24-ELS-01-DUN", cardId: "LT24-ELS-01", finish: "DUN", card: CARD },
+    });
 
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -235,7 +240,10 @@ describe("CollectibleDetailPage – SKU route", () => {
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -495,7 +503,10 @@ describe("resolveTimestamp + formatDate (via component)", () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     renderWithRoute("/collectibles/LT24-ELS-01");
 
-    expect(warnSpy).toHaveBeenCalledWith("Failed to convert Firestore timestamp", expect.any(Error));
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to convert Firestore timestamp",
+      expect.any(Error),
+    );
     expect(screen.queryByText("Last Updated")).not.toBeInTheDocument();
     warnSpy.mockRestore();
   });
@@ -579,7 +590,11 @@ describe("useCollectibleCollectionEntry invocation", () => {
     setDefaults({ card: CARD, user: USER });
     renderWithRoute("/collectibles/LT24-ELS-01");
 
-    expect(useCollectibleCollectionEntry).toHaveBeenCalledWith("user-123", "LT24-ELS-01", undefined);
+    expect(useCollectibleCollectionEntry).toHaveBeenCalledWith(
+      "user-123",
+      "LT24-ELS-01",
+      undefined,
+    );
   });
 
   it("passes null ownerUid when user is not authenticated", () => {
@@ -599,7 +614,10 @@ describe("useCollectibleCollectionEntry invocation", () => {
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -631,7 +649,10 @@ describe("CollectibleDetailPage – data layer", () => {
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );
@@ -648,7 +669,10 @@ describe("CollectibleDetailPage – data layer", () => {
     render(
       <MemoryRouter initialEntries={["/collectibles/LT24-ELS-01/sku/LT24-ELS-01-DUN"]}>
         <Routes>
-          <Route path="/collectibles/:collectibleId/sku/:skuId" element={<CollectibleDetailPage />} />
+          <Route
+            path="/collectibles/:collectibleId/sku/:skuId"
+            element={<CollectibleDetailPage />}
+          />
         </Routes>
       </MemoryRouter>,
     );

--- a/frontend/src/pages/Collectibles/components/CollectiblesToolbar.test.jsx
+++ b/frontend/src/pages/Collectibles/components/CollectiblesToolbar.test.jsx
@@ -5,436 +5,386 @@ import { sortOptions } from "../constants.js";
 import CollectiblesToolbar from "./CollectiblesToolbar.jsx";
 
 const stories = [
-	{ code: "red", title: "Red Riding Hood" },
-	{ code: "snow", title: "Snow White" },
+  { code: "red", title: "Red Riding Hood" },
+  { code: "snow", title: "Snow White" },
 ];
 
 const rarityOptions = ["Common", "Uncommon", "Rare", "Epic"];
 
 function renderToolbar(overrides = {}) {
-	const props = {
-		searchTerm: "",
-		onSearchChange: vi.fn(),
-		categoryFilter: "all",
-		onCategoryChange: vi.fn(),
-		storyFilter: "all",
-		onStoryChange: vi.fn(),
-		rarityFilter: "all",
-		onRarityChange: vi.fn(),
-		sortField: "number",
-		onSortFieldChange: vi.fn(),
-		sortDirection: "asc",
-		onToggleSortDirection: vi.fn(),
-		rarityOptions,
-		stories,
-		resultCount: 42,
-		totalCount: 100,
-		onReset: vi.fn(),
-		...overrides,
-	};
-	return {
-		...props,
-		...render(<CollectiblesToolbar {...props} />),
-	};
+  const props = {
+    searchTerm: "",
+    onSearchChange: vi.fn(),
+    categoryFilter: "all",
+    onCategoryChange: vi.fn(),
+    storyFilter: "all",
+    onStoryChange: vi.fn(),
+    rarityFilter: "all",
+    onRarityChange: vi.fn(),
+    sortField: "number",
+    onSortFieldChange: vi.fn(),
+    sortDirection: "asc",
+    onToggleSortDirection: vi.fn(),
+    rarityOptions,
+    stories,
+    resultCount: 42,
+    totalCount: 100,
+    onReset: vi.fn(),
+    ...overrides,
+  };
+  return {
+    ...props,
+    ...render(<CollectiblesToolbar {...props} />),
+  };
 }
 
 describe("CollectiblesToolbar", () => {
-	describe("structure and layout", () => {
-		it("renders a section with cards-toolbar class", () => {
-			const { container } = renderToolbar();
-			const section = container.querySelector("section.cards-toolbar");
-			expect(section).toBeInTheDocument();
-		});
-
-		it("renders search input with correct id, type, and placeholder", () => {
-			renderToolbar();
-			const input = screen.getByLabelText("Search");
-			expect(input).toHaveAttribute("id", "collectible-search");
-			expect(input).toHaveAttribute("type", "search");
-			expect(input).toHaveAttribute(
-				"placeholder",
-				"Search by ID, story, or variant",
-			);
-		});
-
-		it("renders filter controls with correct ids for accessibility", () => {
-			renderToolbar();
-			expect(screen.getByLabelText("Category")).toHaveAttribute(
-				"id",
-				"category-filter",
-			);
-			expect(screen.getByLabelText("Story")).toHaveAttribute(
-				"id",
-				"story-filter",
-			);
-			expect(screen.getByLabelText("Rarity")).toHaveAttribute(
-				"id",
-				"rarity-filter",
-			);
-			expect(screen.getByLabelText("Sort by")).toHaveAttribute(
-				"id",
-				"sort-by",
-			);
-		});
-
-		it("renders sort direction button with descriptive aria-label", () => {
-			renderToolbar({ sortDirection: "asc" });
-			expect(
-				screen.getByRole("button", { name: "Sort ascending" }),
-			).toBeInTheDocument();
-
-			renderToolbar({ sortDirection: "desc" });
-			expect(
-				screen.getByRole("button", { name: "Sort descending" }),
-			).toBeInTheDocument();
-		});
-	});
-
-	describe("search input", () => {
-		it("renders with the current search term", () => {
-			renderToolbar({ searchTerm: "dragon" });
-			expect(screen.getByLabelText("Search")).toHaveValue("dragon");
-		});
-
-		it("calls onSearchChange with the typed value", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-			const input = screen.getByLabelText("Search");
-
-			await user.type(input, "hello");
-			expect(props.onSearchChange).toHaveBeenCalledWith("h");
-			expect(props.onSearchChange).toHaveBeenCalledTimes(5);
-		});
-
-		it("clears search via the native clear action", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar({ searchTerm: "old" });
-			const input = screen.getByLabelText("Search");
-
-			await user.clear(input);
-			expect(props.onSearchChange).toHaveBeenCalledWith("");
-		});
-	});
-
-	describe("category filter", () => {
-		it("renders all category options", () => {
-			renderToolbar();
-			const select = screen.getByLabelText("Category");
-			const options = within(select).getAllByRole("option");
-
-			expect(options.map((o) => o.value)).toEqual([
-				"all",
-				"story",
-				"herald",
-				"nonsense",
-			]);
-		});
-
-		it("reflects the current category", () => {
-			renderToolbar({ categoryFilter: "herald" });
-			expect(screen.getByLabelText("Category")).toHaveValue("herald");
-		});
-
-		it("renders category option labels", () => {
-			renderToolbar();
-			const select = screen.getByLabelText("Category");
-			const options = within(select).getAllByRole("option");
-			expect(options[0]).toHaveTextContent("All categories");
-			expect(options[1]).toHaveTextContent("Story cards");
-			expect(options[2]).toHaveTextContent("Heralds");
-			expect(options[3]).toHaveTextContent("Nonsense variants");
-		});
-
-		it("calls onCategoryChange when selection changes", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Category"), "nonsense");
-			expect(props.onCategoryChange).toHaveBeenCalledWith("nonsense");
-		});
-
-		it("calls onCategoryChange for story, herald, and all", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Category"), "story");
-			expect(props.onCategoryChange).toHaveBeenCalledWith("story");
-
-			await user.selectOptions(screen.getByLabelText("Category"), "herald");
-			expect(props.onCategoryChange).toHaveBeenCalledWith("herald");
-
-			await user.selectOptions(screen.getByLabelText("Category"), "all");
-			expect(props.onCategoryChange).toHaveBeenCalledWith("all");
-		});
-	});
-
-	describe("story filter", () => {
-		it("renders dynamic story options plus static ones", () => {
-			renderToolbar();
-			const select = screen.getByLabelText("Story");
-			const options = within(select).getAllByRole("option");
-
-			expect(options).toHaveLength(stories.length + 2);
-			expect(options[0]).toHaveTextContent("All stories");
-			expect(options[1]).toHaveTextContent("Red Riding Hood");
-			expect(options[2]).toHaveTextContent("Snow White");
-			expect(options[options.length - 1]).toHaveTextContent("Heralds only");
-		});
-
-		it("reflects the current story filter", () => {
-			renderToolbar({ storyFilter: "snow" });
-			expect(screen.getByLabelText("Story")).toHaveValue("snow");
-		});
-
-		it("calls onStoryChange when selection changes", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Story"), "red");
-			expect(props.onStoryChange).toHaveBeenCalledWith("red");
-		});
-
-		it("calls onStoryChange for Heralds only option", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Story"), "heralds");
-			expect(props.onStoryChange).toHaveBeenCalledWith("heralds");
-		});
-
-		it("reflects heralds filter when selected", () => {
-			renderToolbar({ storyFilter: "heralds" });
-			expect(screen.getByLabelText("Story")).toHaveValue("heralds");
-		});
-	});
-
-	describe("rarity filter", () => {
-		it("renders dynamic rarity options plus static ones", () => {
-			renderToolbar();
-			const select = screen.getByLabelText("Rarity");
-			const options = within(select).getAllByRole("option");
-
-			expect(options).toHaveLength(rarityOptions.length + 2);
-			expect(options[0]).toHaveTextContent("All rarities");
-			expect(options[options.length - 1]).toHaveTextContent(
-				"No rarity (nonsense)",
-			);
-		});
-
-		it("reflects the current rarity filter", () => {
-			renderToolbar({ rarityFilter: "Rare" });
-			expect(screen.getByLabelText("Rarity")).toHaveValue("Rare");
-		});
-
-		it("calls onRarityChange when selection changes", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Rarity"), "Epic");
-			expect(props.onRarityChange).toHaveBeenCalledWith("Epic");
-		});
-
-		it("calls onRarityChange for No rarity (nonsense) option", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Rarity"), "none");
-			expect(props.onRarityChange).toHaveBeenCalledWith("none");
-		});
-
-		it("reflects none filter when selected", () => {
-			renderToolbar({ rarityFilter: "none" });
-			expect(screen.getByLabelText("Rarity")).toHaveValue("none");
-		});
-	});
-
-	describe("sort controls", () => {
-		it("renders all sort options from constants", () => {
-			renderToolbar();
-			const select = screen.getByLabelText("Sort by");
-			const options = within(select).getAllByRole("option");
-
-			expect(options.map((o) => o.value)).toEqual(
-				sortOptions.map((o) => o.value),
-			);
-			expect(options.map((o) => o.textContent)).toEqual(
-				sortOptions.map((o) => o.label),
-			);
-		});
-
-		it("reflects the current sort field", () => {
-			renderToolbar({ sortField: "rarity" });
-			expect(screen.getByLabelText("Sort by")).toHaveValue("rarity");
-		});
-
-		it("calls onSortFieldChange when selection changes", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.selectOptions(screen.getByLabelText("Sort by"), "story");
-			expect(props.onSortFieldChange).toHaveBeenCalledWith("story");
-		});
-
-		it("calls onSortFieldChange for each sort option from constants", async () => {
-			const user = userEvent.setup();
-			for (let i = 0; i < sortOptions.length; i++) {
-				cleanup();
-				const option = sortOptions[i];
-				const prevOption =
-					sortOptions[(i + 1) % sortOptions.length];
-				const onSortFieldChange = vi.fn();
-				renderToolbar({
-					onSortFieldChange,
-					sortField: prevOption.value,
-				});
-				await user.selectOptions(
-					screen.getByLabelText("Sort by"),
-					option.value,
-				);
-				expect(onSortFieldChange).toHaveBeenCalledWith(option.value);
-			}
-		});
-
-		it("sort direction button has sort-direction class", () => {
-			renderToolbar();
-			const button = screen.getByRole("button", {
-				name: "Sort ascending",
-			});
-			expect(button).toHaveClass("sort-direction");
-		});
-
-		it("shows ascending arrow and label when sortDirection is asc", () => {
-			renderToolbar({ sortDirection: "asc" });
-			const button = screen.getByRole("button", {
-				name: "Sort ascending",
-			});
-			expect(button).toHaveTextContent("↑");
-		});
-
-		it("shows descending arrow and label when sortDirection is desc", () => {
-			renderToolbar({ sortDirection: "desc" });
-			const button = screen.getByRole("button", {
-				name: "Sort descending",
-			});
-			expect(button).toHaveTextContent("↓");
-		});
-
-		it("calls onToggleSortDirection when the direction button is clicked", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.click(
-				screen.getByRole("button", { name: "Sort ascending" }),
-			);
-			expect(props.onToggleSortDirection).toHaveBeenCalledOnce();
-		});
-	});
-
-	describe("toolbar footer", () => {
-		it("displays result and total counts", () => {
-			renderToolbar({ resultCount: 7, totalCount: 250 });
-			expect(screen.getByText(/showing/i).textContent).toBe(
-				"Showing 7 of 250 collectibles",
-			);
-		});
-
-		it("calls onReset when the reset button is clicked", async () => {
-			const user = userEvent.setup();
-			const props = renderToolbar();
-
-			await user.click(
-				screen.getByRole("button", { name: /reset filters/i }),
-			);
-			expect(props.onReset).toHaveBeenCalledOnce();
-		});
-
-		it("reset button has reset-button class", () => {
-			renderToolbar();
-			const button = screen.getByRole("button", {
-				name: /reset filters/i,
-			});
-			expect(button).toHaveClass("reset-button");
-		});
-	});
-
-	describe("edge cases", () => {
-		it("renders with empty stories and rarityOptions", () => {
-			renderToolbar({ stories: [], rarityOptions: [] });
-
-			const storyOptions = within(
-				screen.getByLabelText("Story"),
-			).getAllByRole("option");
-			expect(storyOptions).toHaveLength(2);
-
-			const rarityOpts = within(
-				screen.getByLabelText("Rarity"),
-			).getAllByRole("option");
-			expect(rarityOpts).toHaveLength(2);
-		});
-
-		it("renders zero counts", () => {
-			renderToolbar({ resultCount: 0, totalCount: 0 });
-			expect(screen.getByText(/showing/i).textContent).toBe(
-				"Showing 0 of 0 collectibles",
-			);
-		});
-
-		it("displays counts with strong emphasis", () => {
-			renderToolbar({ resultCount: 5, totalCount: 100 });
-			const resultStrong = screen.getByText("5").closest("strong");
-			const totalStrong = screen.getByText("100").closest("strong");
-			expect(resultStrong).toBeInTheDocument();
-			expect(totalStrong).toBeInTheDocument();
-		});
-	});
-
-	describe("onChange handler behavior", () => {
-		it("onSearchChange receives event.target.value (typed character)", async () => {
-			const user = userEvent.setup();
-			const onSearchChange = vi.fn();
-			renderToolbar({ onSearchChange });
-
-			await user.type(screen.getByLabelText("Search"), "x");
-			expect(onSearchChange).toHaveBeenLastCalledWith("x");
-		});
-
-		it("all callback props are invoked with correct values", async () => {
-			const user = userEvent.setup();
-			const callbacks = {
-				onSearchChange: vi.fn(),
-				onCategoryChange: vi.fn(),
-				onStoryChange: vi.fn(),
-				onRarityChange: vi.fn(),
-				onSortFieldChange: vi.fn(),
-				onToggleSortDirection: vi.fn(),
-				onReset: vi.fn(),
-			};
-			renderToolbar(callbacks);
-
-			await user.type(screen.getByLabelText("Search"), "test");
-			expect(callbacks.onSearchChange).toHaveBeenCalled();
-
-			await user.selectOptions(screen.getByLabelText("Category"), "story");
-			expect(callbacks.onCategoryChange).toHaveBeenCalledWith("story");
-
-			await user.selectOptions(screen.getByLabelText("Story"), "red");
-			expect(callbacks.onStoryChange).toHaveBeenCalledWith("red");
-
-			await user.selectOptions(screen.getByLabelText("Rarity"), "Common");
-			expect(callbacks.onRarityChange).toHaveBeenCalledWith("Common");
-
-			await user.selectOptions(screen.getByLabelText("Sort by"), "id");
-			expect(callbacks.onSortFieldChange).toHaveBeenCalledWith("id");
-
-			await user.click(
-				screen.getByRole("button", { name: "Sort ascending" }),
-			);
-			expect(callbacks.onToggleSortDirection).toHaveBeenCalled();
-
-			await user.click(
-				screen.getByRole("button", { name: /reset filters/i }),
-			);
-			expect(callbacks.onReset).toHaveBeenCalled();
-		});
-	});
+  describe("structure and layout", () => {
+    it("renders a section with cards-toolbar class", () => {
+      const { container } = renderToolbar();
+      const section = container.querySelector("section.cards-toolbar");
+      expect(section).toBeInTheDocument();
+    });
+
+    it("renders search input with correct id, type, and placeholder", () => {
+      renderToolbar();
+      const input = screen.getByLabelText("Search");
+      expect(input).toHaveAttribute("id", "collectible-search");
+      expect(input).toHaveAttribute("type", "search");
+      expect(input).toHaveAttribute("placeholder", "Search by ID, story, or variant");
+    });
+
+    it("renders filter controls with correct ids for accessibility", () => {
+      renderToolbar();
+      expect(screen.getByLabelText("Category")).toHaveAttribute("id", "category-filter");
+      expect(screen.getByLabelText("Story")).toHaveAttribute("id", "story-filter");
+      expect(screen.getByLabelText("Rarity")).toHaveAttribute("id", "rarity-filter");
+      expect(screen.getByLabelText("Sort by")).toHaveAttribute("id", "sort-by");
+    });
+
+    it("renders sort direction button with descriptive aria-label", () => {
+      renderToolbar({ sortDirection: "asc" });
+      expect(screen.getByRole("button", { name: "Sort ascending" })).toBeInTheDocument();
+
+      renderToolbar({ sortDirection: "desc" });
+      expect(screen.getByRole("button", { name: "Sort descending" })).toBeInTheDocument();
+    });
+  });
+
+  describe("search input", () => {
+    it("renders with the current search term", () => {
+      renderToolbar({ searchTerm: "dragon" });
+      expect(screen.getByLabelText("Search")).toHaveValue("dragon");
+    });
+
+    it("calls onSearchChange with the typed value", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+      const input = screen.getByLabelText("Search");
+
+      await user.type(input, "hello");
+      expect(props.onSearchChange).toHaveBeenCalledWith("h");
+      expect(props.onSearchChange).toHaveBeenCalledTimes(5);
+    });
+
+    it("clears search via the native clear action", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar({ searchTerm: "old" });
+      const input = screen.getByLabelText("Search");
+
+      await user.clear(input);
+      expect(props.onSearchChange).toHaveBeenCalledWith("");
+    });
+  });
+
+  describe("category filter", () => {
+    it("renders all category options", () => {
+      renderToolbar();
+      const select = screen.getByLabelText("Category");
+      const options = within(select).getAllByRole("option");
+
+      expect(options.map((o) => o.value)).toEqual(["all", "story", "herald", "nonsense"]);
+    });
+
+    it("reflects the current category", () => {
+      renderToolbar({ categoryFilter: "herald" });
+      expect(screen.getByLabelText("Category")).toHaveValue("herald");
+    });
+
+    it("renders category option labels", () => {
+      renderToolbar();
+      const select = screen.getByLabelText("Category");
+      const options = within(select).getAllByRole("option");
+      expect(options[0]).toHaveTextContent("All categories");
+      expect(options[1]).toHaveTextContent("Story cards");
+      expect(options[2]).toHaveTextContent("Heralds");
+      expect(options[3]).toHaveTextContent("Nonsense variants");
+    });
+
+    it("calls onCategoryChange when selection changes", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Category"), "nonsense");
+      expect(props.onCategoryChange).toHaveBeenCalledWith("nonsense");
+    });
+
+    it("calls onCategoryChange for story, herald, and all", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Category"), "story");
+      expect(props.onCategoryChange).toHaveBeenCalledWith("story");
+
+      await user.selectOptions(screen.getByLabelText("Category"), "herald");
+      expect(props.onCategoryChange).toHaveBeenCalledWith("herald");
+
+      await user.selectOptions(screen.getByLabelText("Category"), "all");
+      expect(props.onCategoryChange).toHaveBeenCalledWith("all");
+    });
+  });
+
+  describe("story filter", () => {
+    it("renders dynamic story options plus static ones", () => {
+      renderToolbar();
+      const select = screen.getByLabelText("Story");
+      const options = within(select).getAllByRole("option");
+
+      expect(options).toHaveLength(stories.length + 2);
+      expect(options[0]).toHaveTextContent("All stories");
+      expect(options[1]).toHaveTextContent("Red Riding Hood");
+      expect(options[2]).toHaveTextContent("Snow White");
+      expect(options[options.length - 1]).toHaveTextContent("Heralds only");
+    });
+
+    it("reflects the current story filter", () => {
+      renderToolbar({ storyFilter: "snow" });
+      expect(screen.getByLabelText("Story")).toHaveValue("snow");
+    });
+
+    it("calls onStoryChange when selection changes", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Story"), "red");
+      expect(props.onStoryChange).toHaveBeenCalledWith("red");
+    });
+
+    it("calls onStoryChange for Heralds only option", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Story"), "heralds");
+      expect(props.onStoryChange).toHaveBeenCalledWith("heralds");
+    });
+
+    it("reflects heralds filter when selected", () => {
+      renderToolbar({ storyFilter: "heralds" });
+      expect(screen.getByLabelText("Story")).toHaveValue("heralds");
+    });
+  });
+
+  describe("rarity filter", () => {
+    it("renders dynamic rarity options plus static ones", () => {
+      renderToolbar();
+      const select = screen.getByLabelText("Rarity");
+      const options = within(select).getAllByRole("option");
+
+      expect(options).toHaveLength(rarityOptions.length + 2);
+      expect(options[0]).toHaveTextContent("All rarities");
+      expect(options[options.length - 1]).toHaveTextContent("No rarity (nonsense)");
+    });
+
+    it("reflects the current rarity filter", () => {
+      renderToolbar({ rarityFilter: "Rare" });
+      expect(screen.getByLabelText("Rarity")).toHaveValue("Rare");
+    });
+
+    it("calls onRarityChange when selection changes", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Rarity"), "Epic");
+      expect(props.onRarityChange).toHaveBeenCalledWith("Epic");
+    });
+
+    it("calls onRarityChange for No rarity (nonsense) option", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Rarity"), "none");
+      expect(props.onRarityChange).toHaveBeenCalledWith("none");
+    });
+
+    it("reflects none filter when selected", () => {
+      renderToolbar({ rarityFilter: "none" });
+      expect(screen.getByLabelText("Rarity")).toHaveValue("none");
+    });
+  });
+
+  describe("sort controls", () => {
+    it("renders all sort options from constants", () => {
+      renderToolbar();
+      const select = screen.getByLabelText("Sort by");
+      const options = within(select).getAllByRole("option");
+
+      expect(options.map((o) => o.value)).toEqual(sortOptions.map((o) => o.value));
+      expect(options.map((o) => o.textContent)).toEqual(sortOptions.map((o) => o.label));
+    });
+
+    it("reflects the current sort field", () => {
+      renderToolbar({ sortField: "rarity" });
+      expect(screen.getByLabelText("Sort by")).toHaveValue("rarity");
+    });
+
+    it("calls onSortFieldChange when selection changes", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.selectOptions(screen.getByLabelText("Sort by"), "story");
+      expect(props.onSortFieldChange).toHaveBeenCalledWith("story");
+    });
+
+    it("calls onSortFieldChange for each sort option from constants", async () => {
+      const user = userEvent.setup();
+      for (let i = 0; i < sortOptions.length; i++) {
+        cleanup();
+        const option = sortOptions[i];
+        const prevOption = sortOptions[(i + 1) % sortOptions.length];
+        const onSortFieldChange = vi.fn();
+        renderToolbar({
+          onSortFieldChange,
+          sortField: prevOption.value,
+        });
+        await user.selectOptions(screen.getByLabelText("Sort by"), option.value);
+        expect(onSortFieldChange).toHaveBeenCalledWith(option.value);
+      }
+    });
+
+    it("sort direction button has sort-direction class", () => {
+      renderToolbar();
+      const button = screen.getByRole("button", {
+        name: "Sort ascending",
+      });
+      expect(button).toHaveClass("sort-direction");
+    });
+
+    it("shows ascending arrow and label when sortDirection is asc", () => {
+      renderToolbar({ sortDirection: "asc" });
+      const button = screen.getByRole("button", {
+        name: "Sort ascending",
+      });
+      expect(button).toHaveTextContent("↑");
+    });
+
+    it("shows descending arrow and label when sortDirection is desc", () => {
+      renderToolbar({ sortDirection: "desc" });
+      const button = screen.getByRole("button", {
+        name: "Sort descending",
+      });
+      expect(button).toHaveTextContent("↓");
+    });
+
+    it("calls onToggleSortDirection when the direction button is clicked", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+      expect(props.onToggleSortDirection).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe("toolbar footer", () => {
+    it("displays result and total counts", () => {
+      renderToolbar({ resultCount: 7, totalCount: 250 });
+      expect(screen.getByText(/showing/i).textContent).toBe("Showing 7 of 250 collectibles");
+    });
+
+    it("calls onReset when the reset button is clicked", async () => {
+      const user = userEvent.setup();
+      const props = renderToolbar();
+
+      await user.click(screen.getByRole("button", { name: /reset filters/i }));
+      expect(props.onReset).toHaveBeenCalledOnce();
+    });
+
+    it("reset button has reset-button class", () => {
+      renderToolbar();
+      const button = screen.getByRole("button", {
+        name: /reset filters/i,
+      });
+      expect(button).toHaveClass("reset-button");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("renders with empty stories and rarityOptions", () => {
+      renderToolbar({ stories: [], rarityOptions: [] });
+
+      const storyOptions = within(screen.getByLabelText("Story")).getAllByRole("option");
+      expect(storyOptions).toHaveLength(2);
+
+      const rarityOpts = within(screen.getByLabelText("Rarity")).getAllByRole("option");
+      expect(rarityOpts).toHaveLength(2);
+    });
+
+    it("renders zero counts", () => {
+      renderToolbar({ resultCount: 0, totalCount: 0 });
+      expect(screen.getByText(/showing/i).textContent).toBe("Showing 0 of 0 collectibles");
+    });
+
+    it("displays counts with strong emphasis", () => {
+      renderToolbar({ resultCount: 5, totalCount: 100 });
+      const resultStrong = screen.getByText("5").closest("strong");
+      const totalStrong = screen.getByText("100").closest("strong");
+      expect(resultStrong).toBeInTheDocument();
+      expect(totalStrong).toBeInTheDocument();
+    });
+  });
+
+  describe("onChange handler behavior", () => {
+    it("onSearchChange receives event.target.value (typed character)", async () => {
+      const user = userEvent.setup();
+      const onSearchChange = vi.fn();
+      renderToolbar({ onSearchChange });
+
+      await user.type(screen.getByLabelText("Search"), "x");
+      expect(onSearchChange).toHaveBeenLastCalledWith("x");
+    });
+
+    it("all callback props are invoked with correct values", async () => {
+      const user = userEvent.setup();
+      const callbacks = {
+        onSearchChange: vi.fn(),
+        onCategoryChange: vi.fn(),
+        onStoryChange: vi.fn(),
+        onRarityChange: vi.fn(),
+        onSortFieldChange: vi.fn(),
+        onToggleSortDirection: vi.fn(),
+        onReset: vi.fn(),
+      };
+      renderToolbar(callbacks);
+
+      await user.type(screen.getByLabelText("Search"), "test");
+      expect(callbacks.onSearchChange).toHaveBeenCalled();
+
+      await user.selectOptions(screen.getByLabelText("Category"), "story");
+      expect(callbacks.onCategoryChange).toHaveBeenCalledWith("story");
+
+      await user.selectOptions(screen.getByLabelText("Story"), "red");
+      expect(callbacks.onStoryChange).toHaveBeenCalledWith("red");
+
+      await user.selectOptions(screen.getByLabelText("Rarity"), "Common");
+      expect(callbacks.onRarityChange).toHaveBeenCalledWith("Common");
+
+      await user.selectOptions(screen.getByLabelText("Sort by"), "id");
+      expect(callbacks.onSortFieldChange).toHaveBeenCalledWith("id");
+
+      await user.click(screen.getByRole("button", { name: "Sort ascending" }));
+      expect(callbacks.onToggleSortDirection).toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: /reset filters/i }));
+      expect(callbacks.onReset).toHaveBeenCalled();
+    });
+  });
 });

--- a/frontend/src/pages/Collectibles/hooks/useAddToCollection.test.js
+++ b/frontend/src/pages/Collectibles/hooks/useAddToCollection.test.js
@@ -82,9 +82,7 @@ describe("useAddToCollection", () => {
       const { result } = renderHook(() => useAddToCollection());
 
       await expect(
-        act(() =>
-          result.current.addToCollection({ card: { id: "LT24-ELS-01" }, finish: null }),
-        ),
+        act(() => result.current.addToCollection({ card: { id: "LT24-ELS-01" }, finish: null })),
       ).rejects.toThrow("A finish is required");
     });
 
@@ -122,11 +120,14 @@ describe("useAddToCollection", () => {
       expect(result.current.error).toBeNull();
 
       expect(mockCollection).toHaveBeenCalledWith({ type: "mock-firestore" }, "collections");
-      expect(mockAddDoc).toHaveBeenCalledWith("collections-ref", expect.objectContaining({
-        ownerUid: "user-123",
-        skuId: "LT24-ELS-01-DUN",
-        quantity: 1,
-      }));
+      expect(mockAddDoc).toHaveBeenCalledWith(
+        "collections-ref",
+        expect.objectContaining({
+          ownerUid: "user-123",
+          skuId: "LT24-ELS-01-DUN",
+          quantity: 1,
+        }),
+      );
 
       expect(payload.ownerUid).toBe("user-123");
       expect(payload.skuId).toBe("LT24-ELS-01-DUN");

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -14,11 +14,7 @@ export default defineConfig({
       reporter: ["text", "text-summary", "html"],
       include: ["src/**/*.{js,jsx}"],
       // Only exclude test files and test harness so they are not counted as production source.
-      exclude: [
-        "src/**/*.test.{js,jsx}",
-        "src/**/*.spec.{js,jsx}",
-        "src/test/**",
-      ],
+      exclude: ["src/**/*.test.{js,jsx}", "src/**/*.spec.{js,jsx}", "src/test/**"],
     },
   },
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `frontend/src/lib/firebase.test.js` to unit-test the Firebase bootstrap module with mocked `firebase/app`, `firebase/auth`, `firebase/firestore`, and `firebase/functions`.

Also applies **Biome formatting** across several frontend test files and `frontend/vite.config.js` so `biome ci` passes (including `CreateListingForm.test.jsx` indent and coverage `exclude` array layout).

## What is covered

- Missing or invalid `VITE_FIREBASE_*` config (`hasFirebaseConfig`, `console.warn`, null exports).
- `initializeApp` vs `getApp` when `getApps()` is empty vs non-empty.
- Emulator mode: `VITE_USE_EMULATORS` case-insensitive, default and overridden emulator URLs/hosts/ports.
- `try`/`catch` paths for `connectAuthEmulator`, `connectFirestoreEmulator`, and `connectFunctionsEmulator` (`console.debug`).
- `setPersistence` rejection (`console.error`).
- Skipping emulator setup when Firebase is not configured.
- OAuth provider `setCustomParameters` when auth exists.

`vi.stubEnv` drives `import.meta.env`; `vi.resetModules()` plus dynamic `import()` re-runs the module per scenario.

## Verification

`cd frontend && npm run test:coverage` — `src/lib/firebase.js` reports **100%** statements/lines and **~85%** branch coverage (above the requested ≥80% for this file).

`npx biome ci .` at repo root passes (one existing `useConst` warning in `useAddToCollection.test.js`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97b88120-ad1e-4146-ba55-f24b5420cf5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97b88120-ad1e-4146-ba55-f24b5420cf5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

