### PR TITLE
test(frontend): Vitest coverage for main.jsx entry point

### DIFF
--- a/frontend/src/main.test.jsx
+++ b/frontend/src/main.test.jsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCreateRoot, mockRender } = vi.hoisted(() => {
+  const mockRender = vi.fn();
+  const mockCreateRoot = vi.fn(() => ({ render: mockRender }));
+  return { mockCreateRoot, mockRender };
+});
+
+vi.mock("react-dom/client", () => ({
+  default: {
+    createRoot: (...args) => mockCreateRoot(...args),
+  },
+}));
+
+vi.mock("./App.jsx", () => ({
+  default: function MockApp() {
+    return <span data-testid="mock-app">App</span>;
+  },
+}));
+
+vi.mock("./contexts/AuthContext.jsx", () => ({
+  AuthProvider: ({ children }) => <div data-testid="auth-provider">{children}</div>,
+}));
+
+vi.mock("./contexts/AuthModalContext.jsx", () => ({
+  AuthModalProvider: ({ children }) => <div data-testid="auth-modal-provider">{children}</div>,
+}));
+
+async function loadMain() {
+  vi.resetModules();
+  await import("./main.jsx");
+}
+
+describe("main.jsx (entry)", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="root"></div>';
+    mockCreateRoot.mockClear();
+    mockRender.mockClear();
+  });
+
+  it("creates a root on #root and renders the provider tree under StrictMode", async () => {
+    const rootEl = document.getElementById("root");
+    await loadMain();
+
+    expect(mockCreateRoot).toHaveBeenCalledTimes(1);
+    expect(mockCreateRoot).toHaveBeenCalledWith(rootEl);
+    expect(mockRender).toHaveBeenCalledTimes(1);
+
+    const tree = mockRender.mock.calls[0][0];
+    expect(tree.type).toBe(React.StrictMode);
+
+    render(tree);
+    expect(screen.getByTestId("auth-provider")).toBeInTheDocument();
+    expect(screen.getByTestId("auth-modal-provider")).toBeInTheDocument();
+    expect(screen.getByTestId("mock-app")).toBeInTheDocument();
+  });
+
+  it("wires the same root element returned by the document", async () => {
+    const getById = vi.spyOn(document, "getElementById");
+    await loadMain();
+
+    expect(getById).toHaveBeenCalledWith("root");
+    expect(mockCreateRoot).toHaveBeenCalledWith(document.getElementById("root"));
+    getById.mockRestore();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `frontend/src/main.test.jsx` to exercise the React bootstrap in `main.jsx` without mounting the real app or Firebase-backed providers.

## Approach

- `vi.hoisted` + `vi.mock("react-dom/client")` to capture `createRoot` and `.render()` calls.
- Mock `App`, `AuthProvider`, and `AuthModalProvider` as lightweight shells.
- `vi.resetModules()` + dynamic `import("./main.jsx")` so the entry module’s top-level side effects run once per test (Vitest module cache otherwise prevents re-execution).
- Assert `#root` is passed to `createRoot`, the rendered tree is `React.StrictMode`, and nested providers + mock app appear when the captured element is rendered with Testing Library.

## Verification

`cd frontend && npm run test:coverage` — `main.jsx` reports **100%** statements/branches/functions/lines (well above the requested 80% for this file).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9267106a-ad25-453d-8044-dcd1b1b3fb5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9267106a-ad25-453d-8044-dcd1b1b3fb5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

