### PR TITLE
test(Card): expand Vitest/RTL coverage for flip, stamp, and keyboard

### DIFF
--- a/frontend/src/components/Card/Card.test.jsx
+++ b/frontend/src/components/Card/Card.test.jsx
@@ -1,9 +1,13 @@
-import { render } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import Card from "./Card.jsx";
 
 describe("Card (integration)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("locks a hover flip so the card stays flipped", async () => {
     const user = userEvent.setup();
     const { container } = render(
@@ -24,5 +28,214 @@ describe("Card (integration)", () => {
 
     await user.unhover(card);
     expect(card).toHaveClass("flipped", "locked");
+  });
+
+  it("clears hover flip when pointer leaves while unlocked", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Card frontContent={<span>Front</span>} backContent={<span>Back</span>} isNonsense={false} />,
+    );
+    const card = container.firstElementChild;
+
+    await user.hover(card);
+    expect(card).toHaveClass("flipped");
+    await user.unhover(card);
+    expect(card).not.toHaveClass("flipped");
+  });
+
+  it("locks the unflipped state when clicked without hovering and notifies onFlip", () => {
+    const onFlip = vi.fn();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        onFlip={onFlip}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+
+    // fireEvent.click avoids user-event's implicit pointer enter, which would flip via hover first
+    fireEvent.click(card);
+    expect(card).toHaveClass("locked");
+    expect(card).not.toHaveClass("flipped");
+    expect(onFlip).toHaveBeenCalledWith(false);
+  });
+
+  it("locks and unlocks without onFlip callback", () => {
+    const { container } = render(
+      <Card frontContent={<span>Front</span>} backContent={<span>Back</span>} isNonsense={false} />,
+    );
+    const card = container.firstElementChild;
+
+    fireEvent.click(card);
+    expect(card).toHaveClass("locked");
+
+    fireEvent.click(card);
+    expect(card).not.toHaveClass("locked");
+  });
+
+  it("calls onClick on each card click", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        onClick={onClick}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+
+    await user.click(card);
+    await user.click(card);
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("unlocks on second click and calls onFlip(false)", async () => {
+    const user = userEvent.setup();
+    const onFlip = vi.fn();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        onFlip={onFlip}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+
+    await user.hover(card);
+    await user.click(card);
+    expect(onFlip).toHaveBeenLastCalledWith(true);
+
+    await user.click(card);
+    expect(card).not.toHaveClass("locked");
+    expect(onFlip).toHaveBeenLastCalledWith(false);
+  });
+
+  it("uses controlled isFlipped when locking without hover", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        isFlipped={true}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+
+    await user.click(card);
+    expect(card).toHaveClass("flipped", "locked");
+  });
+
+  it("ignores hover enter and leave while locked", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Card frontContent={<span>Front</span>} backContent={<span>Back</span>} isNonsense={false} />,
+    );
+    const card = container.firstElementChild;
+
+    fireEvent.click(card);
+    expect(card).not.toHaveClass("flipped");
+
+    await user.hover(card);
+    expect(card).not.toHaveClass("flipped");
+
+    await user.unhover(card);
+    expect(card).not.toHaveClass("flipped");
+  });
+
+  it("activates the card on Enter and Space", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        onClick={onClick}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+    card.focus();
+
+    await user.keyboard("{Enter}");
+    expect(onClick).toHaveBeenCalledTimes(1);
+
+    await user.keyboard(" ");
+    expect(onClick).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not activate on unrelated keys", async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        onClick={onClick}
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+    card.focus();
+
+    await user.keyboard("a");
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it("renders nonsense stamp with a fixed position when provided", () => {
+    render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        isNonsense
+        nonsensePosition={2}
+      />,
+    );
+    const stamp = screen.getByText("NONSENSE");
+    expect(stamp).toBeInTheDocument();
+    expect(stamp.closest(".card-stamp")).toHaveStyle({
+      top: "15%",
+      left: "50%",
+    });
+  });
+
+  it("picks a random stamp slot when nonsensePosition is omitted", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    render(<Card frontContent={<span>Front</span>} backContent={<span>Back</span>} isNonsense />);
+    const stamp = screen.getByText("NONSENSE");
+    expect(stamp.closest(".card-stamp")).toHaveStyle({ top: "15%", left: "15%" });
+  });
+
+  it("uses fallback stamp layout for unknown nonsense positions", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        isNonsense
+        nonsensePosition={0}
+      />,
+    );
+    const stamp = screen.getByText("NONSENSE");
+    expect(stamp.closest(".card-stamp")).toBeTruthy();
+    expect(stamp.closest(".card-stamp").style.transform).toMatch(/rotate/);
+  });
+
+  it("applies non-default theme CSS variables", () => {
+    const { container } = render(
+      <Card
+        frontContent={<span>Front</span>}
+        backContent={<span>Back</span>}
+        theme="elsecaller"
+        isNonsense={false}
+      />,
+    );
+    const card = container.firstElementChild;
+    expect(card.style.getPropertyValue("--card-primary").trim()).toBe("#8C5AC8");
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds integration-style tests for `Card.jsx` so branch coverage on that file rises from ~73% to **~97%** (threshold goal was ≥80%).

## What is covered

- **Lock without prior hover**: `fireEvent.click` avoids user-event’s implicit pointer enter so `handleCardClick` runs with `isHovered === false` (`onFlip(false)`).
- **Lock/unlock with no `onFlip`**: optional callback branches on both paths.
- **`onClick`** firing on repeated clicks.
- **Controlled `isFlipped`**: locking while not hovered respects the prop.
- **Hover handlers while locked**: `mouseenter` / `mouseleave` no-ops when `isLocked`.
- **Keyboard**: `Enter` and `Space` trigger the same path as click; unrelated keys do not.
- **Nonsense stamp**: fixed `nonsensePosition`, random slot via mocked `Math.random`, and unknown position exercising `positionMap[position] || {}`.
- **Theme**: non-default `theme` applies expected CSS variables.
- **Mouse leave while unlocked**: clears hover flip.

## Verification

```bash
cd frontend && npm run test:coverage
```

`Card.jsx` reports **96.87%** branches in the coverage table (one minor branch remains on line 49 per Istanbul).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-589660c4-ef73-4b6a-8358-361faf334f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-589660c4-ef73-4b6a-8358-361faf334f28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

