### PR TITLE
docs: AGENTS.md pre-commit check for Cursor Cloud

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ Lost Tales Marketplace is a single-product Vite + React 18 SPA (`frontend/`) bac
 2. **Frontend**: `cd frontend && npm install`
 3. **Functions** (if you change or debug callable code with the emulator): `cd functions && npm install`
 
+Before `git commit`, run `npm run check` from the repo root (same as `biome check --write .`). That mirrors the local pre-commit hook intent without relying on Husky in the VM.
+
 Default Firebase project id matches `.firebaserc`: `storydeck-16`.
 
 ### Running locally


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a short note under **Cursor Cloud specific instructions** in `AGENTS.md`: before `git commit`, run `npm run check` from the repo root (equivalent to `biome check --write .`) so cloud agents align with the local Husky/lint-staged intent when Husky is not active in the VM.

## Changes

- `AGENTS.md`: one paragraph after the Setup list.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e367390f-11ce-4ea6-891f-290e51f620e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e367390f-11ce-4ea6-891f-290e51f620e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

