### PR TITLE
test(Collection): unit tests for useUserCollection hook

### DIFF
--- a/frontend/src/pages/Collection/hooks/useUserCollection.test.js
+++ b/frontend/src/pages/Collection/hooks/useUserCollection.test.js
@@ -1,0 +1,143 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDb = { _tag: "mock-firestore" };
+vi.mock("../../../lib/firebase", () => ({ db: mockDb }));
+
+const mockCollection = vi.fn();
+const mockWhere = vi.fn();
+const mockQuery = vi.fn();
+const mockOnSnapshot = vi.fn();
+
+vi.mock("firebase/firestore", () => ({
+  collection: (...args) => mockCollection(...args),
+  where: (...args) => mockWhere(...args),
+  query: (...args) => mockQuery(...args),
+  onSnapshot: (...args) => mockOnSnapshot(...args),
+}));
+
+let useUserCollection;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+
+  mockCollection.mockReturnValue("collections-ref");
+  mockWhere.mockReturnValue("where-constraint");
+  mockQuery.mockReturnValue("query-ref");
+  mockOnSnapshot.mockReturnValue(vi.fn());
+
+  const mod = await import("./useUserCollection.js");
+  useUserCollection = mod.useUserCollection;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createFakeDoc(id, data) {
+  return {
+    id,
+    data: () => data,
+  };
+}
+
+describe("useUserCollection", () => {
+  describe("when ownerUid is falsy", () => {
+    it("returns empty entries, loading=false, error=null", async () => {
+      const { result } = renderHook(() => useUserCollection(null));
+
+      await waitFor(() => {
+        expect(result.current.loading).toBe(false);
+      });
+
+      expect(result.current.entries).toEqual([]);
+      expect(result.current.error).toBe(null);
+    });
+
+    it("does not subscribe to Firestore", async () => {
+      renderHook(() => useUserCollection(undefined));
+
+      await waitFor(() => {
+        expect(mockOnSnapshot).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when ownerUid is set", () => {
+    it("builds collection, query, and where for ownerUid", () => {
+      renderHook(() => useUserCollection("user-abc"));
+
+      expect(mockCollection).toHaveBeenCalledWith(mockDb, "collections");
+      expect(mockWhere).toHaveBeenCalledWith("ownerUid", "==", "user-abc");
+      expect(mockQuery).toHaveBeenCalledWith("collections-ref", "where-constraint");
+    });
+
+    it("sets loading=true while waiting for snapshot", () => {
+      const { result } = renderHook(() => useUserCollection("user-abc"));
+
+      expect(result.current.loading).toBe(true);
+      expect(result.current.error).toBe(null);
+    });
+
+    it("subscribes to onSnapshot with the query and callbacks", () => {
+      renderHook(() => useUserCollection("user-abc"));
+
+      expect(mockOnSnapshot).toHaveBeenCalledTimes(1);
+      expect(mockOnSnapshot).toHaveBeenCalledWith(
+        "query-ref",
+        expect.any(Function),
+        expect.any(Function),
+      );
+    });
+
+    it("on success: maps snapshot docs to entries and clears loading", () => {
+      const { result } = renderHook(() => useUserCollection("user-abc"));
+
+      const onNext = mockOnSnapshot.mock.calls[0][1];
+      const fakeSnap = {
+        docs: [
+          createFakeDoc("doc-1", { ownerUid: "user-abc", skuId: "LT24-ELS-01-DUN", quantity: 2 }),
+          createFakeDoc("doc-2", { ownerUid: "user-abc", skuId: "LT24-WOK-01-DUN", quantity: 1 }),
+        ],
+      };
+
+      act(() => onNext(fakeSnap));
+
+      expect(result.current.entries).toEqual([
+        { id: "doc-1", ownerUid: "user-abc", skuId: "LT24-ELS-01-DUN", quantity: 2 },
+        { id: "doc-2", ownerUid: "user-abc", skuId: "LT24-WOK-01-DUN", quantity: 1 },
+      ]);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.error).toBe(null);
+    });
+
+    it("on error: sets error, stops loading, and logs", () => {
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { result } = renderHook(() => useUserCollection("user-abc"));
+
+      const onError = mockOnSnapshot.mock.calls[0][2];
+      const fakeError = new Error("permission-denied");
+
+      act(() => onError(fakeError));
+
+      expect(result.current.error).toBe(fakeError);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.entries).toEqual([]);
+      expect(consoleSpy).toHaveBeenCalledWith("Failed to load collection entries", fakeError);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("calls unsubscribe on unmount", () => {
+      const unsubscribe = vi.fn();
+      mockOnSnapshot.mockReturnValue(unsubscribe);
+
+      const { unmount } = renderHook(() => useUserCollection("user-abc"));
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+
+      unmount();
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Vitest coverage for `useUserCollection` by mocking Firebase Firestore (`collection`, `query`, `where`, `onSnapshot`) and `db` from the app Firebase module.

## Coverage

- Falsy `ownerUid`: empty `entries`, `loading=false`, `error=null`, no `onSnapshot` subscription (after effects flush).
- Set `ownerUid`: correct query wiring, `loading=true` until snapshot, success callback maps docs to `{ id, ...data }`, error callback sets `error` and logs, cleanup calls unsubscribe on unmount.

`npm run test:coverage` from `frontend/` passes; `useUserCollection.js` reports 100% line/statement coverage in the Vitest v8 report.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2360b721-d6b3-4349-8456-2cf1dc399312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2360b721-d6b3-4349-8456-2cf1dc399312"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

