### PR TITLE
test(Market): unit tests for useOpenListings

### DIFF
--- a/frontend/src/pages/Market/hooks/useOpenListings.test.js
+++ b/frontend/src/pages/Market/hooks/useOpenListings.test.js
@@ -1,0 +1,134 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../lib/marketplace/listings", () => ({
+  subscribeOpenListings: vi.fn(),
+}));
+
+import { subscribeOpenListings } from "../../../lib/marketplace/listings";
+import useOpenListings from "./useOpenListings.js";
+
+describe("useOpenListings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    subscribeOpenListings.mockImplementation((_params, _onNext, _onError) => vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts in loading state with empty listings and no error", () => {
+    const { result } = renderHook(() => useOpenListings());
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.listings).toEqual([]);
+    expect(result.current.error).toBe(null);
+    expect(subscribeOpenListings).toHaveBeenCalledTimes(1);
+  });
+
+  it("subscribes with params without cardId (undefined)", () => {
+    renderHook(() => useOpenListings());
+
+    expect(subscribeOpenListings).toHaveBeenCalledWith(
+      { cardId: undefined },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("subscribes with params including cardId when provided", () => {
+    renderHook(() => useOpenListings({ cardId: "LT24-ELS-01" }));
+
+    expect(subscribeOpenListings).toHaveBeenCalledWith(
+      { cardId: "LT24-ELS-01" },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("maps snapshot docs to listings and clears loading on success", () => {
+    const { result } = renderHook(() => useOpenListings());
+
+    const onNext = subscribeOpenListings.mock.calls[0][1];
+    const fakeSnap = {
+      docs: [
+        { id: "listing-1", data: () => ({ status: "OPEN", priceCents: 100 }) },
+        { id: "listing-2", data: () => ({ status: "OPEN", cardId: "LT24-ELS-01" }) },
+      ],
+    };
+
+    act(() => onNext(fakeSnap));
+
+    expect(result.current.listings).toEqual([
+      { id: "listing-1", status: "OPEN", priceCents: 100 },
+      { id: "listing-2", status: "OPEN", cardId: "LT24-ELS-01" },
+    ]);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it("handles an empty snapshot", () => {
+    const { result } = renderHook(() => useOpenListings());
+    const onNext = subscribeOpenListings.mock.calls[0][1];
+
+    act(() => onNext({ docs: [] }));
+
+    expect(result.current.listings).toEqual([]);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it("invokes error callback: sets error, stops loading, and logs", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const { result } = renderHook(() => useOpenListings());
+    const onError = subscribeOpenListings.mock.calls[0][2];
+    const fakeError = new Error("permission-denied");
+
+    act(() => onError(fakeError));
+
+    expect(result.current.error).toBe(fakeError);
+    expect(result.current.loading).toBe(false);
+    expect(result.current.listings).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to load open listings", fakeError);
+
+    consoleSpy.mockRestore();
+  });
+
+  it("calls unsubscribe returned by subscribeOpenListings on unmount", () => {
+    const unsubscribe = vi.fn();
+    subscribeOpenListings.mockReturnValue(unsubscribe);
+
+    const { unmount } = renderHook(() => useOpenListings());
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    unmount();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("resubscribes when cardId changes and unsubscribes from prior subscription", () => {
+    const unsub1 = vi.fn();
+    const unsub2 = vi.fn();
+    subscribeOpenListings.mockReturnValueOnce(unsub1).mockReturnValueOnce(unsub2);
+
+    const { rerender } = renderHook(({ cardId }) => useOpenListings({ cardId }), {
+      initialProps: { cardId: undefined },
+    });
+
+    expect(subscribeOpenListings).toHaveBeenCalledTimes(1);
+    expect(subscribeOpenListings).toHaveBeenLastCalledWith(
+      { cardId: undefined },
+      expect.any(Function),
+      expect.any(Function),
+    );
+
+    rerender({ cardId: "LT24-ELS-01" });
+
+    expect(unsub1).toHaveBeenCalledTimes(1);
+    expect(subscribeOpenListings).toHaveBeenCalledTimes(2);
+    expect(subscribeOpenListings).toHaveBeenLastCalledWith(
+      { cardId: "LT24-ELS-01" },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Vitest coverage for `useOpenListings` by mocking `subscribeOpenListings` from `lib/marketplace/listings`.

## What is covered

- Initial loading state (`loading: true`, empty listings, no error)
- Success path: snapshot `docs` mapped to `{ id, ...data() }`, loading cleared
- Error path: `setError`, loading cleared, `console.error` with the expected message
- Unmount: the unsubscribe function returned from `subscribeOpenListings` is invoked
- Subscription params with and without `cardId` (`{ cardId: undefined }` vs a concrete id)
- Resubscribe when `cardId` changes (prior unsubscribe called)

## Verification

`cd frontend && npm run test:coverage` — `useOpenListings.js` reports 100% statements/branches/functions/lines.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8bbd8bc5-9afd-4c93-8bd2-c591326f75e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8bbd8bc5-9afd-4c93-8bd2-c591326f75e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

