### PR TITLE
CI: parallel jobs, Playwright cache, concurrency

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -3,10 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+# Free-tier friendly: drop redundant runs when new commits land on the same branch.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  test:
+  biome:
+    name: Biome
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,29 +26,68 @@ jobs:
         with:
           node-version: "22"
           cache: npm
-          cache-dependency-path: |
-            package-lock.json
-            frontend/package-lock.json
-            functions/package-lock.json
+          cache-dependency-path: package-lock.json
       - name: Install root dependencies (Biome)
         run: npm ci
       - name: Biome check
         run: npm run ci
+
+  frontend-test:
+    name: Frontend unit & coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
-      - name: Production build
-        working-directory: frontend
-        run: npm run build
       - name: Unit, integration & coverage thresholds
         working-directory: frontend
         run: npm run test:coverage
+
+  functions-test:
+    name: Cloud Functions tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: functions/package-lock.json
       - name: Install functions dependencies
         working-directory: functions
         run: npm ci
       - name: Cloud Functions unit tests
         working-directory: functions
         run: npm test
+
+  frontend-e2e:
+    name: Frontend E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+      - name: Production build
+        working-directory: frontend
+        run: npm run build
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
       - name: Install Playwright Chromium
         working-directory: frontend
         run: npx playwright install chromium --with-deps
@@ -46,3 +97,25 @@ jobs:
         env:
           CI: true
           PLAYWRIGHT_SKIP_BUILD: "1"
+
+  # Single job for branch protection: require this instead of four parallel jobs.
+  ci-success:
+    name: CI success
+    runs-on: ubuntu-latest
+    needs: [biome, frontend-test, functions-test, frontend-e2e]
+    if: always()
+    steps:
+      - name: Verify required jobs succeeded
+        env:
+          BIOME: ${{ needs.biome.result }}
+          FRONTEND_TEST: ${{ needs.frontend-test.result }}
+          FUNCTIONS_TEST: ${{ needs.functions-test.result }}
+          E2E: ${{ needs.frontend-e2e.result }}
+        run: |
+          for name_result in "biome=$BIOME" "frontend-test=$FRONTEND_TEST" "functions-test=$FUNCTIONS_TEST" "frontend-e2e=$E2E"; do
+            r="${name_result#*=}"
+            if [ "$r" != "success" ]; then
+              echo "Not all jobs succeeded: biome=$BIOME frontend-test=$FRONTEND_TEST functions-test=$FUNCTIONS_TEST frontend-e2e=$E2E"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reorganizes the GitHub Actions workflow to improve **wall-clock time** on the free tier without adding paid features.

### Changes

1. **Parallel jobs** — Biome, frontend Vitest/coverage, Cloud Functions tests, and Playwright E2E each run on their own runner. Previously everything was sequential on one job.

2. **Playwright browser cache** — Caches `~/.cache/ms-playwright` keyed on `frontend/package-lock.json` so Chromium is not fully re-downloaded every run (install step still runs for validation).

3. **Concurrency** — `cancel-in-progress` for the same PR or ref so rapid pushes do not leave multiple full CI runs consuming minutes.

4. **`paths-ignore`** — Skips the workflow for changes that only touch `**.md` or `docs/**` (still runs when code or config changes).

5. **`ci-success` job** — Aggregates the four parallel jobs so branch protection can require a **single** check name (`CI success`) instead of four separate required statuses.

### Follow-up for repo settings

If branch protection currently requires a job named **test**, update it to require **CI success** (or require all four named jobs).

### Trade-offs

- **Total Actions minutes** can be slightly higher in parallel (four runners × shorter time) vs one long job; **elapsed time** for the workflow should drop noticeably.
- Doc-only PRs no longer run CI; adjust `paths-ignore` if you want stricter behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8555ec64-f248-4890-8cad-8f395b813c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8555ec64-f248-4890-8cad-8f395b813c88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

