### PR TITLE
test(Collection): BulkCollectionTools unit tests

### DIFF
--- a/frontend/src/pages/Collection/components/BulkCollectionTools.test.jsx
+++ b/frontend/src/pages/Collection/components/BulkCollectionTools.test.jsx
@@ -1,0 +1,344 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import BulkCollectionTools from "./BulkCollectionTools.jsx";
+
+const bulkImportMocks = vi.hoisted(() => ({
+  createCollectionTemplateCsv: vi.fn(() => "skuId,quantity,notes\n"),
+  parseBulkCollectionCsv: vi.fn(),
+  applyBulkCollectionUpdate: vi.fn(),
+}));
+
+vi.mock("../utils/bulkImport", () => ({
+  createCollectionTemplateCsv: bulkImportMocks.createCollectionTemplateCsv,
+  parseBulkCollectionCsv: bulkImportMocks.parseBulkCollectionCsv,
+  applyBulkCollectionUpdate: bulkImportMocks.applyBulkCollectionUpdate,
+}));
+
+const collectiblesState = vi.hoisted(() => ({
+  skus: [],
+  stories: [{ title: "Zeta" }, { title: "Alpha" }],
+  cardById: {},
+}));
+
+vi.mock("../../../data/collectibles", () => ({
+  get datasetSkus() {
+    return collectiblesState.skus;
+  },
+  get datasetStories() {
+    return collectiblesState.stories;
+  },
+  getCollectibleRecord: (cardId) => collectiblesState.cardById[cardId] ?? null,
+}));
+
+describe("BulkCollectionTools", () => {
+  const ownerUid = "user-abc";
+
+  beforeEach(() => {
+    bulkImportMocks.createCollectionTemplateCsv.mockReturnValue("skuId,quantity,notes\n");
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      issues: [],
+    });
+    collectiblesState.skus = [];
+    collectiblesState.stories = [{ title: "Zeta" }, { title: "Alpha" }];
+    collectiblesState.cardById = {};
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    URL.createObjectURL = vi.fn(() => "blob:mock-url");
+    URL.revokeObjectURL = vi.fn();
+
+    Object.defineProperty(document, "execCommand", {
+      value: vi.fn(() => true),
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function getFileInput(container) {
+    return (container ?? document).querySelector('input[type="file"]');
+  }
+
+  function uploadCsv(container, name = "test.csv", content = "x") {
+    const input = getFileInput(container);
+    const file = new File([content], name, { type: "text/csv" });
+    if (typeof file.text !== "function") {
+      file.text = () => Promise.resolve(String(content));
+    }
+    const fileList = {
+      0: file,
+      length: 1,
+      item: (index) => (index === 0 ? file : null),
+      [Symbol.iterator]: function* fileIterator() {
+        yield file;
+      },
+    };
+    Object.defineProperty(input, "files", {
+      configurable: true,
+      value: fileList,
+    });
+    fireEvent.change(input);
+    return file;
+  }
+
+  it("renders bulk tools section and instructions", () => {
+    render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    expect(screen.getByRole("region", { name: /bulk update tools/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: /bulk update your collection/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/download the csv template, fill in your card counts/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows sign-in hint and disables actions when ownerUid is missing", () => {
+    const { container } = render(<BulkCollectionTools ownerUid={null} entries={[]} />);
+    expect(
+      screen.getByText(/sign in to download the template or upload updates/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download template/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /copy iso\/uft post/i })).toBeDisabled();
+    expect(getFileInput(container)).toBeDisabled();
+  });
+
+  it("enables actions when signed in and not disabled", () => {
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    expect(screen.queryByText(/sign in to download/i)).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /download template/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /copy iso\/uft post/i })).toBeEnabled();
+    expect(getFileInput(container)).toBeEnabled();
+  });
+
+  it("disables actions when disabled prop is true", () => {
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} disabled />);
+    expect(screen.getByRole("button", { name: /download template/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /copy iso\/uft post/i })).toBeDisabled();
+    expect(getFileInput(container)).toBeDisabled();
+  });
+
+  it("downloads CSV template via blob URL when template button is used", async () => {
+    const user = userEvent.setup();
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {});
+
+    render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    await user.click(screen.getByRole("button", { name: /download template/i }));
+
+    expect(bulkImportMocks.createCollectionTemplateCsv).toHaveBeenCalledTimes(1);
+    expect(URL.createObjectURL).toHaveBeenCalled();
+    expect(clickSpy).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+    clickSpy.mockRestore();
+  });
+
+  it("shows uploading label while import is in progress", async () => {
+    let finishImport;
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishImport = resolve;
+        }),
+    );
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "bulk.csv", "x");
+
+    expect(await screen.findByText(/uploading/i)).toBeInTheDocument();
+    finishImport({ created: 1, updated: 0, deleted: 0, issues: [] });
+    await waitFor(() => {
+      expect(screen.queryByText(/uploading/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it("sets error when CSV parses to zero rows", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([]);
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "empty.csv", "h");
+
+    expect(
+      await screen.findByText(/the uploaded file did not contain any collection updates/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/last uploaded file: empty\.csv/i)).toBeInTheDocument();
+  });
+
+  it("applies bulk update and shows summary for a single change type", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({
+      created: 2,
+      updated: 0,
+      deleted: 0,
+      issues: [],
+    });
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "rows.csv", "a");
+
+    expect(await screen.findByText(/2 new entries/i)).toBeInTheDocument();
+    expect(bulkImportMocks.applyBulkCollectionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ownerUid,
+        rows: [{ skuId: "S1", quantity: "1", __lineNumber: 2 }],
+      }),
+    );
+    expect(bulkImportMocks.applyBulkCollectionUpdate.mock.calls[0][0].existingEntries).toEqual([]);
+  });
+
+  it("combines summary segments for multiple change types", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({
+      created: 1,
+      updated: 1,
+      deleted: 1,
+      issues: [],
+    });
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "mix.csv", "a");
+
+    expect(await screen.findByText(/1 new entry, 1 update and 1 removal/i)).toBeInTheDocument();
+  });
+
+  it("shows 'no changes' summary when report counts are all zero", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      issues: [],
+    });
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "noop.csv", "a");
+
+    expect(await screen.findByText(/no changes were necessary/i)).toBeInTheDocument();
+  });
+
+  it("shows import issues including rows with unknown line numbers", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({
+      created: 0,
+      updated: 0,
+      deleted: 0,
+      issues: [
+        { line: 3, message: "Bad row" },
+        { line: "?", message: "Ambiguous" },
+      ],
+    });
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "issues.csv", "a");
+
+    expect(await screen.findByText(/some rows were skipped/i)).toBeInTheDocument();
+    expect(screen.getByText(/line 3: bad row/i)).toBeInTheDocument();
+    expect(screen.getByText(/row: ambiguous/i)).toBeInTheDocument();
+  });
+
+  it("shows error message when bulk import throws", async () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockRejectedValue(new Error("Firestore exploded"));
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    uploadCsv(container, "bad.csv", "a");
+
+    expect(await screen.findByText(/firestore exploded/i)).toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("uses execCommand fallback when clipboard has no writeText", async () => {
+    const user = userEvent.setup();
+    Reflect.deleteProperty(globalThis.navigator, "clipboard");
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: {},
+      configurable: true,
+      writable: true,
+    });
+    const execCommand = vi.mocked(document.execCommand);
+    execCommand.mockClear();
+    collectiblesState.skus = [];
+
+    render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    await user.click(screen.getByRole("button", { name: /copy iso\/uft post/i }));
+
+    expect(execCommand).toHaveBeenCalledWith("copy");
+    expect(await screen.findByText(/copied iso\/uft post to your clipboard/i)).toBeInTheDocument();
+  });
+
+  it("shows success status after copy ISO/UFT post", async () => {
+    const user = userEvent.setup();
+    collectiblesState.skus = [];
+
+    render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    await user.click(screen.getByRole("button", { name: /copy iso\/uft post/i }));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(/copied iso\/uft post/i);
+  });
+
+  it("shows post copy error when clipboard writeText rejects", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.fn().mockRejectedValue(new Error("denied"));
+    Reflect.deleteProperty(globalThis.navigator, "clipboard");
+    Object.defineProperty(globalThis.navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+      writable: true,
+    });
+    collectiblesState.skus = [];
+
+    render(<BulkCollectionTools ownerUid={ownerUid} entries={[]} />);
+    await user.click(screen.getByRole("button", { name: /copy iso\/uft post/i }));
+
+    expect(await screen.findByText(/unable to copy the post/i)).toBeInTheDocument();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it("passes existing entries from props into applyBulkCollectionUpdate", async () => {
+    const existing = [{ id: "e1", skuId: "LT-X" }];
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+    bulkImportMocks.applyBulkCollectionUpdate.mockResolvedValue({ created: 1, issues: [] });
+
+    const { container } = render(<BulkCollectionTools ownerUid={ownerUid} entries={existing} />);
+    uploadCsv(container, "with-existing.csv", "a");
+
+    await waitFor(() => {
+      expect(bulkImportMocks.applyBulkCollectionUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({ existingEntries: existing }),
+      );
+    });
+  });
+
+  it("does not run file import when ownerUid is missing", () => {
+    bulkImportMocks.parseBulkCollectionCsv.mockReturnValue([
+      { skuId: "S1", quantity: "1", __lineNumber: 2 },
+    ]);
+
+    const { container } = render(<BulkCollectionTools ownerUid={null} entries={[]} />);
+    const input = getFileInput(container);
+    expect(input).toBeDisabled();
+    uploadCsv(container, "nope.csv", "a");
+
+    expect(bulkImportMocks.parseBulkCollectionCsv).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds Vitest + React Testing Library coverage for `BulkCollectionTools.jsx` with mocks for `bulkImport` (Firestore stays behind that boundary) and `collectibles` catalog data.

## What is covered
- Layout, sign-in hint, and disabled states (including `disabled` prop)
- Template download (blob URL + anchor click)
- CSV upload: in-progress UI, empty parse result, success summaries (single and combined), no-op report, row issues, thrown errors
- Copy ISO/UFT: `execCommand` fallback when `clipboard.writeText` is missing, generic success status, and error when `writeText` rejects
- `existingEntries` passed through to `applyBulkCollectionUpdate`, and no import when signed out

## Coverage note
`BulkCollectionTools.jsx` lands around **~73%** statements in `npm run test:coverage`—intentionally lighter than an exhaustive ISO/UFT string-building suite so tests stay stable across jsdom navigator differences.

## Verification
`cd frontend && npm run test:coverage`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f30d067f-b5ef-4873-a391-460e1def6915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f30d067f-b5ef-4873-a391-460e1def6915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

