### PR TITLE
test(market): improve Market page Vitest coverage

### DIFF
--- a/frontend/src/pages/Market/index.test.jsx
+++ b/frontend/src/pages/Market/index.test.jsx
@@ -219,6 +219,17 @@ describe("MarketPage (integration)", () => {
     alertSpy.mockRestore();
   });
 
+  it("alerts with default message when acceptListing rejects without a message", async () => {
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    mockAcceptListing.mockRejectedValueOnce({});
+    renderMarket();
+    await userEvent.click(screen.getByRole("button", { name: "Accept" }));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("Failed to accept listing");
+    });
+    alertSpy.mockRestore();
+  });
+
   it("alerts when cancelListing fails", async () => {
     const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
     mockUseAuth.mockReturnValue({ user: SELLER });
@@ -228,6 +239,19 @@ describe("MarketPage (integration)", () => {
     await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
     await waitFor(() => {
       expect(alertSpy).toHaveBeenCalledWith("cancel failed");
+    });
+    alertSpy.mockRestore();
+  });
+
+  it("alerts with default message when cancelListing rejects without a message", async () => {
+    const alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    mockUseAuth.mockReturnValue({ user: SELLER });
+    mockUseOpenListings.mockReturnValue({ listings: [listingAsk], loading: false, error: null });
+    mockCancelListing.mockRejectedValueOnce({});
+    renderMarket();
+    await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith("Failed to cancel listing");
     });
     alertSpy.mockRestore();
   });
@@ -328,6 +352,45 @@ describe("MarketPage (integration)", () => {
       );
     });
     expect(await screen.findByText("Listing created.")).toBeInTheDocument();
+  });
+
+  it("uses email as display name when creating a listing and displayName is missing", async () => {
+    mockUseAuth.mockReturnValue({
+      user: { uid: "u1", email: "only@example.com", displayName: null },
+    });
+    renderMarket();
+    await userEvent.click(screen.getAllByRole("button", { name: "Create listing" })[0]);
+    await userEvent.type(screen.getByPlaceholderText("Search by card name or id"), "LT24-ELS-01");
+    await userEvent.type(screen.getByPlaceholderText("10.00"), "1");
+    await userEvent.click(submitCreateInDialog());
+    await waitFor(() => {
+      expect(mockCreateListing).toHaveBeenCalledWith(
+        expect.objectContaining({ createdByDisplayName: "only@example.com" }),
+      );
+    });
+  });
+
+  it("shows Creating… on submit while createListing is in flight", async () => {
+    let releaseCreate;
+    mockCreateListing.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          releaseCreate = resolve;
+        }),
+    );
+    renderMarket();
+    await userEvent.click(screen.getAllByRole("button", { name: "Create listing" })[0]);
+    await userEvent.type(screen.getByPlaceholderText("Search by card name or id"), "LT24-ELS-01");
+    await userEvent.type(screen.getByPlaceholderText("10.00"), "9");
+    await userEvent.click(submitCreateInDialog());
+    expect(await screen.findByRole("button", { name: "Creating…" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(releaseCreate).toEqual(expect.any(Function));
+    });
+    releaseCreate({ id: "x" });
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Creating…" })).not.toBeInTheDocument();
+    });
   });
 
   it("navigates to login when submitting create form logged out", async () => {

--- a/frontend/src/pages/Market/index.unauthHandlers.test.jsx
+++ b/frontend/src/pages/Market/index.unauthHandlers.test.jsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import MarketPage from "./index.jsx";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
+const mockUseAuth = vi.fn();
+vi.mock("../../contexts/AuthContext", () => ({
+  useAuth: (...args) => mockUseAuth(...args),
+}));
+
+const mockUseOpenListings = vi.fn();
+vi.mock("./hooks/useOpenListings", () => ({
+  default: (...args) => mockUseOpenListings(...args),
+}));
+
+vi.mock("../../lib/marketplace/listings", () => ({
+  cancelListing: vi.fn(),
+  acceptListing: vi.fn(),
+  createListing: vi.fn(),
+}));
+
+/**
+ * Real ListingRow disables Accept when logged out, so handleAccept/handleCancel
+ * login redirects never run from the UI. Stub rows so we can invoke those handlers.
+ */
+vi.mock("./components/ListingRow", () => ({
+  default: function ListingRowStub({ listing, onAccept, onCancel }) {
+    return (
+      <li>
+        <button type="button" onClick={() => onAccept?.(listing)}>
+          Test accept listing
+        </button>
+        <button type="button" onClick={() => onCancel?.(listing)}>
+          Test cancel listing
+        </button>
+      </li>
+    );
+  },
+}));
+
+vi.mock("firebase/firestore", () => ({
+  addDoc: vi.fn(),
+  collection: vi.fn(),
+  doc: vi.fn(),
+  onSnapshot: vi.fn(() => () => {}),
+  orderBy: vi.fn(),
+  query: vi.fn(),
+  runTransaction: vi.fn(),
+  serverTimestamp: vi.fn(),
+  where: vi.fn(),
+}));
+
+const listingAsk = {
+  id: "listing-ask-1",
+  type: "ASK",
+  priceCents: 999,
+  currency: "USD",
+  cardId: "LT24-ELS-01",
+  createdByUid: "seller-uid",
+  createdByDisplayName: "Seller",
+};
+
+function renderMarket() {
+  return render(
+    <MemoryRouter>
+      <MarketPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseAuth.mockReturnValue({ user: null });
+  mockUseOpenListings.mockReturnValue({
+    listings: [listingAsk],
+    loading: false,
+    error: null,
+  });
+});
+
+describe("MarketPage unauthenticated listing actions", () => {
+  it("redirects to login when accept handler runs without a user", async () => {
+    renderMarket();
+    await userEvent.click(screen.getByRole("button", { name: "Test accept listing" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
+      state: { from: { pathname: "/market" } },
+    });
+  });
+
+  it("redirects to login when cancel handler runs without a user", async () => {
+    renderMarket();
+    await userEvent.click(screen.getByRole("button", { name: "Test cancel listing" }));
+    expect(mockNavigate).toHaveBeenCalledWith("/auth/login", {
+      state: { from: { pathname: "/market" } },
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds and extends Vitest tests for `frontend/src/pages/Market/index.jsx` so statement coverage for that file is well above the 80% target (about **99.5%** in full `npm run test:coverage` runs).

## Changes

- **`index.unauthHandlers.test.jsx`**: Stubs `ListingRow` so `handleAccept` / `handleCancel` run when there is no signed-in user. With the real row, those actions are disabled when logged out, so the login-redirect branches were never exercised.
- **`index.test.jsx`**: Covers alert fallbacks when rejections have no `message`, `createListing` using `email` when `displayName` is missing, and the **Creating…** submit label while `createListing` is pending.

## Verification

- `cd frontend && npm run test:coverage -- --run`
- `npm run check` (repo root)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0b07d9ee-4b17-4ea6-a7e8-dea1533dbc4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0b07d9ee-4b17-4ea6-a7e8-dea1533dbc4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

