### PR TITLE
test(Market): Vitest coverage for useOpenListings

### DIFF
--- a/frontend/src/pages/Market/hooks/useOpenListings.test.js
+++ b/frontend/src/pages/Market/hooks/useOpenListings.test.js
@@ -1,76 +1,103 @@
 import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const mockSubscribeOpenListings = vi.fn();
+
 vi.mock("../../../lib/marketplace/listings", () => ({
-  subscribeOpenListings: vi.fn(),
+  subscribeOpenListings: (...args) => mockSubscribeOpenListings(...args),
 }));
 
-import { subscribeOpenListings } from "../../../lib/marketplace/listings";
-import useOpenListings from "./useOpenListings.js";
+const { default: useOpenListings } = await import("./useOpenListings.js");
+
+function fakeDoc(id, data) {
+  return {
+    id,
+    data: () => data,
+  };
+}
 
 describe("useOpenListings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    subscribeOpenListings.mockImplementation((_params, _onNext, _onError) => vi.fn());
+    mockSubscribeOpenListings.mockImplementation(() => vi.fn());
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("starts in loading state with empty listings and no error", () => {
+  it("starts with loading true, empty listings, and no error", () => {
     const { result } = renderHook(() => useOpenListings());
 
     expect(result.current.loading).toBe(true);
     expect(result.current.listings).toEqual([]);
-    expect(result.current.error).toBe(null);
-    expect(subscribeOpenListings).toHaveBeenCalledTimes(1);
+    expect(result.current.error).toBeNull();
   });
 
-  it("subscribes with params without cardId (undefined)", () => {
+  it("subscribes with cardId undefined when cardId is omitted", () => {
     renderHook(() => useOpenListings());
 
-    expect(subscribeOpenListings).toHaveBeenCalledWith(
+    expect(mockSubscribeOpenListings).toHaveBeenCalledWith(
       { cardId: undefined },
       expect.any(Function),
       expect.any(Function),
     );
   });
 
-  it("subscribes with params including cardId when provided", () => {
+  it("subscribes with cardId undefined when cardId is empty string", () => {
+    renderHook(() => useOpenListings({ cardId: "" }));
+
+    expect(mockSubscribeOpenListings).toHaveBeenCalledWith(
+      { cardId: undefined },
+      expect.any(Function),
+      expect.any(Function),
+    );
+  });
+
+  it("subscribes with the provided cardId", () => {
     renderHook(() => useOpenListings({ cardId: "LT24-ELS-01" }));
 
-    expect(subscribeOpenListings).toHaveBeenCalledWith(
+    expect(mockSubscribeOpenListings).toHaveBeenCalledWith(
       { cardId: "LT24-ELS-01" },
       expect.any(Function),
       expect.any(Function),
     );
   });
 
-  it("maps snapshot docs to listings and clears loading on success", () => {
-    const { result } = renderHook(() => useOpenListings());
+  it("maps snapshot docs to listings and stops loading", () => {
+    let onNext;
+    mockSubscribeOpenListings.mockImplementation((_params, next) => {
+      onNext = next;
+      return vi.fn();
+    });
 
-    const onNext = subscribeOpenListings.mock.calls[0][1];
-    const fakeSnap = {
-      docs: [
-        { id: "listing-1", data: () => ({ status: "OPEN", priceCents: 100 }) },
-        { id: "listing-2", data: () => ({ status: "OPEN", cardId: "LT24-ELS-01" }) },
-      ],
-    };
+    const { result } = renderHook(() => useOpenListings({ cardId: "LT24-ELS-01" }));
 
-    act(() => onNext(fakeSnap));
+    act(() =>
+      onNext({
+        docs: [
+          fakeDoc("l1", { cardId: "LT24-ELS-01", priceCents: 500 }),
+          fakeDoc("l2", { cardId: "LT24-ELS-01", priceCents: 600 }),
+        ],
+      }),
+    );
 
     expect(result.current.listings).toEqual([
-      { id: "listing-1", status: "OPEN", priceCents: 100 },
-      { id: "listing-2", status: "OPEN", cardId: "LT24-ELS-01" },
+      { id: "l1", cardId: "LT24-ELS-01", priceCents: 500 },
+      { id: "l2", cardId: "LT24-ELS-01", priceCents: 600 },
     ]);
     expect(result.current.loading).toBe(false);
-    expect(result.current.error).toBe(null);
+    expect(result.current.error).toBeNull();
   });
 
-  it("handles an empty snapshot", () => {
+  it("handles an empty docs array", () => {
+    let onNext;
+    mockSubscribeOpenListings.mockImplementation((_params, next) => {
+      onNext = next;
+      return vi.fn();
+    });
+
     const { result } = renderHook(() => useOpenListings());
-    const onNext = subscribeOpenListings.mock.calls[0][1];
 
     act(() => onNext({ docs: [] }));
 
@@ -78,25 +105,29 @@ describe("useOpenListings", () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it("invokes error callback: sets error, stops loading, and logs", () => {
+  it("sets error and stops loading when the error callback runs", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let onError;
+    mockSubscribeOpenListings.mockImplementation((_params, _next, err) => {
+      onError = err;
+      return vi.fn();
+    });
+
     const { result } = renderHook(() => useOpenListings());
-    const onError = subscribeOpenListings.mock.calls[0][2];
-    const fakeError = new Error("permission-denied");
+    const failure = new Error("permission-denied");
 
-    act(() => onError(fakeError));
+    act(() => onError(failure));
 
-    expect(result.current.error).toBe(fakeError);
+    expect(result.current.error).toBe(failure);
     expect(result.current.loading).toBe(false);
-    expect(result.current.listings).toEqual([]);
-    expect(consoleSpy).toHaveBeenCalledWith("Failed to load open listings", fakeError);
+    expect(consoleSpy).toHaveBeenCalledWith("Failed to load open listings", failure);
 
     consoleSpy.mockRestore();
   });
 
-  it("calls unsubscribe returned by subscribeOpenListings on unmount", () => {
+  it("calls unsubscribe on unmount", () => {
     const unsubscribe = vi.fn();
-    subscribeOpenListings.mockReturnValue(unsubscribe);
+    mockSubscribeOpenListings.mockReturnValue(unsubscribe);
 
     const { unmount } = renderHook(() => useOpenListings());
     expect(unsubscribe).not.toHaveBeenCalled();
@@ -105,30 +136,61 @@ describe("useOpenListings", () => {
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
-  it("resubscribes when cardId changes and unsubscribes from prior subscription", () => {
+  it("unsubscribes and resubscribes when cardId changes", () => {
     const unsub1 = vi.fn();
     const unsub2 = vi.fn();
-    subscribeOpenListings.mockReturnValueOnce(unsub1).mockReturnValueOnce(unsub2);
+    mockSubscribeOpenListings.mockReturnValueOnce(unsub1).mockReturnValueOnce(unsub2);
 
     const { rerender } = renderHook(({ cardId }) => useOpenListings({ cardId }), {
-      initialProps: { cardId: undefined },
+      initialProps: { cardId: "LT24-ELS-01" },
     });
 
-    expect(subscribeOpenListings).toHaveBeenCalledTimes(1);
-    expect(subscribeOpenListings).toHaveBeenLastCalledWith(
-      { cardId: undefined },
-      expect.any(Function),
-      expect.any(Function),
-    );
+    expect(mockSubscribeOpenListings).toHaveBeenCalledTimes(1);
 
-    rerender({ cardId: "LT24-ELS-01" });
+    rerender({ cardId: "LT24-WOK-01" });
 
     expect(unsub1).toHaveBeenCalledTimes(1);
-    expect(subscribeOpenListings).toHaveBeenCalledTimes(2);
-    expect(subscribeOpenListings).toHaveBeenLastCalledWith(
-      { cardId: "LT24-ELS-01" },
+    expect(mockSubscribeOpenListings).toHaveBeenCalledTimes(2);
+    expect(mockSubscribeOpenListings).toHaveBeenLastCalledWith(
+      { cardId: "LT24-WOK-01" },
       expect.any(Function),
       expect.any(Function),
     );
+  });
+
+  it("resets error and sets loading when effect re-runs after cardId change", () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let onErrorFirst;
+    let onNextSecond;
+    mockSubscribeOpenListings
+      .mockImplementationOnce((_p, _n, err) => {
+        onErrorFirst = err;
+        return vi.fn();
+      })
+      .mockImplementationOnce((_p, next) => {
+        onNextSecond = next;
+        return vi.fn();
+      });
+
+    const { rerender, result } = renderHook(({ cardId }) => useOpenListings({ cardId }), {
+      initialProps: { cardId: "a" },
+    });
+
+    act(() => onErrorFirst(new Error("first")));
+
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.loading).toBe(false);
+
+    rerender({ cardId: "b" });
+
+    expect(result.current.loading).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    act(() => onNextSecond({ docs: [fakeDoc("x", { status: "OPEN" })] }));
+
+    expect(result.current.listings).toEqual([{ id: "x", status: "OPEN" }]);
+    expect(result.current.loading).toBe(false);
+
+    consoleSpy.mockRestore();
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds unit tests for `frontend/src/pages/Market/hooks/useOpenListings.js` by mocking `subscribeOpenListings` from `lib/marketplace/listings`, matching patterns used in `useAddToCollection.test.js` and `useCollectibleCollectionEntry.test.js` (`renderHook`, `act`, `vi.mock`).

## Coverage

- `useOpenListings.js`: **100%** statements (was ~11% before these tests).

## What is tested

- Initial loading state and subscription params (`cardId` omitted, empty string, and concrete id).
- Snapshot success path: `docs` mapped to `{ id, ...data() }`, loading cleared.
- Empty snapshot, error callback (`console.error` + `error` state), unsubscribe on unmount.
- Resubscribe when `cardId` changes; effect clears error and sets loading when deps change.

## Verification

`cd frontend && npm run test:coverage` — all tests pass; coverage thresholds satisfied.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4496b9e-edde-427a-b00e-6bcaf10d6713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4496b9e-edde-427a-b00e-6bcaf10d6713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

