### PR TITLE
perf: optimize 10 slowest Vitest tests (~65% aggregate reduction)

### DIFF
--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,5 +1,16 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("./lib/firebase", () => ({
+  app: null,
+  auth: null,
+  db: null,
+  functions: null,
+  githubProvider: null,
+  googleProvider: null,
+  hasFirebaseConfig: false,
+}));
+
 import App from "./App.jsx";
 import { AuthProvider } from "./contexts/AuthContext.jsx";
 import { AuthModalProvider } from "./contexts/AuthModalContext.jsx";
@@ -16,6 +27,8 @@ describe("App (integration)", () => {
   it("renders primary navigation for a signed-out user after auth finishes loading", async () => {
     renderWithAppProviders(<App />);
     expect(screen.getByRole("link", { name: "Collectibles" })).toBeInTheDocument();
-    expect(await screen.findByRole("link", { name: /sign in/i })).toBeInTheDocument();
+    expect(
+      await screen.findByRole("link", { name: /sign in/i }, { timeout: 500 }),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/Auth/AuthModal.test.jsx
+++ b/frontend/src/components/Auth/AuthModal.test.jsx
@@ -37,11 +37,13 @@ function renderModal(props = {}) {
 
 describe("AuthModal (unit)", () => {
   let consoleErrorSpy;
+  let user;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockError = null;
     consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    user = userEvent.setup({ delay: null });
   });
 
   afterEach(() => {
@@ -78,16 +80,15 @@ describe("AuthModal (unit)", () => {
   });
 
   it("close button resets state, clears error, and calls onClose", async () => {
-    const user = userEvent.setup();
     const { onClose } = renderModal();
-    await user.type(screen.getByLabelText(/^Email$/i), "a@b.com");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("a@b.com");
     await user.click(screen.getByRole("button", { name: "×" }));
     expect(mockClearError).toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("switches to register mode and clears error", async () => {
-    const user = userEvent.setup();
     renderModal();
     mockClearError.mockClear();
     await user.click(screen.getByRole("button", { name: /Need an account/i }));
@@ -99,7 +100,6 @@ describe("AuthModal (unit)", () => {
   });
 
   it("switches from register back to login via switcher", async () => {
-    const user = userEvent.setup();
     renderModal();
     await user.click(screen.getByRole("button", { name: /Need an account/i }));
     await user.click(screen.getByRole("button", { name: /Already have an account/i }));
@@ -107,7 +107,6 @@ describe("AuthModal (unit)", () => {
   });
 
   it("switches to forgot password mode and hides password field", async () => {
-    const user = userEvent.setup();
     renderModal();
     await user.click(screen.getByText("Forgot password?"));
     expect(screen.getByRole("heading", { name: "Reset Password" })).toBeInTheDocument();
@@ -116,46 +115,52 @@ describe("AuthModal (unit)", () => {
   });
 
   it("updates controlled fields via handleChange", async () => {
-    const user = userEvent.setup();
     renderModal();
     await user.click(screen.getByRole("button", { name: /Need an account/i }));
-    await user.type(screen.getByLabelText(/^Display Name$/i), "Pat");
-    await user.type(screen.getByLabelText(/^Email$/i), "pat@example.com");
-    await user.type(screen.getByLabelText(/^Password$/i), "secret12");
+    await user.click(screen.getByLabelText(/^Display Name$/i));
+    await user.paste("Pat");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("pat@example.com");
+    await user.click(screen.getByLabelText(/^Password$/i));
+    await user.paste("secret12");
     expect(screen.getByLabelText(/^Display Name$/i)).toHaveValue("Pat");
     expect(screen.getByLabelText(/^Email$/i)).toHaveValue("pat@example.com");
     expect(screen.getByLabelText(/^Password$/i)).toHaveValue("secret12");
   });
 
   it("submits login and closes on success", async () => {
-    const user = userEvent.setup();
     mockLogin.mockResolvedValueOnce(undefined);
     const { onClose } = renderModal();
-    await user.type(screen.getByLabelText(/^Email$/i), "u@x.com");
-    await user.type(screen.getByLabelText(/^Password$/i), "pw123456");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("u@x.com");
+    await user.click(screen.getByLabelText(/^Password$/i));
+    await user.paste("pw123456");
     await user.click(screen.getByRole("button", { name: "Sign In" }));
     expect(mockLogin).toHaveBeenCalledWith("u@x.com", "pw123456");
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("logs when login rejects", async () => {
-    const user = userEvent.setup();
     mockLogin.mockRejectedValueOnce(new Error("nope"));
     renderModal();
-    await user.type(screen.getByLabelText(/^Email$/i), "u2@x.com");
-    await user.type(screen.getByLabelText(/^Password$/i), "pw222222");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("u2@x.com");
+    await user.click(screen.getByLabelText(/^Password$/i));
+    await user.paste("pw222222");
     await user.click(screen.getByRole("button", { name: "Sign In" }));
     expect(consoleErrorSpy).toHaveBeenCalledWith("Login failed", expect.any(Error));
   });
 
   it("submits register with displayName and closes on success", async () => {
-    const user = userEvent.setup();
     const { onClose } = renderModal();
     await user.click(screen.getByRole("button", { name: /Need an account/i }));
     mockRegister.mockResolvedValueOnce(undefined);
-    await user.type(screen.getByLabelText(/^Display Name$/i), "Sam");
-    await user.type(screen.getByLabelText(/^Email$/i), "sam@example.com");
-    await user.type(screen.getByLabelText(/^Password$/i), "pw123456");
+    await user.click(screen.getByLabelText(/^Display Name$/i));
+    await user.paste("Sam");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("sam@example.com");
+    await user.click(screen.getByLabelText(/^Password$/i));
+    await user.paste("pw123456");
     await user.click(screen.getByRole("button", { name: "Sign Up" }));
     expect(mockRegister).toHaveBeenCalledWith("sam@example.com", "pw123456", {
       displayName: "Sam",
@@ -164,36 +169,38 @@ describe("AuthModal (unit)", () => {
   });
 
   it("logs when registration rejects", async () => {
-    const user = userEvent.setup();
     renderModal();
     await user.click(screen.getByRole("button", { name: /Need an account/i }));
     mockRegister.mockRejectedValueOnce(new Error("reg fail"));
-    await user.type(screen.getByLabelText(/^Display Name$/i), "Other");
-    await user.type(screen.getByLabelText(/^Email$/i), "other@example.com");
-    await user.type(screen.getByLabelText(/^Password$/i), "pw123456");
+    await user.click(screen.getByLabelText(/^Display Name$/i));
+    await user.paste("Other");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("other@example.com");
+    await user.click(screen.getByLabelText(/^Password$/i));
+    await user.paste("pw123456");
     await user.click(screen.getByRole("button", { name: "Sign Up" }));
     expect(consoleErrorSpy).toHaveBeenCalledWith("Registration failed", expect.any(Error));
   });
 
   it("submits forgot password, closes on success, and logs on failure", async () => {
-    const user = userEvent.setup();
     const { onClose } = renderModal();
     await user.click(screen.getByText("Forgot password?"));
     mockResetPassword.mockResolvedValueOnce(undefined);
-    await user.type(screen.getByLabelText(/^Email$/i), "reset@example.com");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("reset@example.com");
     await user.click(screen.getByRole("button", { name: "Send Reset Email" }));
     expect(mockResetPassword).toHaveBeenCalledWith("reset@example.com");
     expect(onClose).toHaveBeenCalledTimes(1);
 
     await user.click(screen.getByText("Forgot password?"));
     mockResetPassword.mockRejectedValueOnce(new Error("reset fail"));
-    await user.type(screen.getByLabelText(/^Email$/i), "bad@example.com");
+    await user.click(screen.getByLabelText(/^Email$/i));
+    await user.paste("bad@example.com");
     await user.click(screen.getByRole("button", { name: "Send Reset Email" }));
     expect(consoleErrorSpy).toHaveBeenCalledWith("Reset password failed", expect.any(Error));
   });
 
   it("invokes onClose when mocked social login triggers onSuccess", async () => {
-    const user = userEvent.setup();
     const { onClose } = renderModal();
     await user.click(screen.getByTestId("social-mock-success"));
     expect(mockClearError).toHaveBeenCalled();

--- a/frontend/src/pages/Account/index.test.jsx
+++ b/frontend/src/pages/Account/index.test.jsx
@@ -118,6 +118,12 @@ describe("AccountPage", () => {
   // ── Additional contact info form ────────────────────────────────────────
 
   describe("additional contact info form", () => {
+    let user;
+
+    beforeEach(() => {
+      user = userEvent.setup({ delay: null });
+    });
+
     it("renders the Additional contact information section heading", () => {
       renderAccountPage();
       expect(
@@ -142,7 +148,6 @@ describe("AccountPage", () => {
     });
 
     it("updates the phone number field on input", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const input = screen.getByLabelText("Phone number");
       await user.type(input, "555-1234");
@@ -150,7 +155,6 @@ describe("AccountPage", () => {
     });
 
     it("updates the mailing address field on input", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const textarea = screen.getByLabelText("Mailing address");
       await user.type(textarea, "123 Main St");
@@ -158,7 +162,6 @@ describe("AccountPage", () => {
     });
 
     it("updates the primary backup email field on input", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const input = screen.getByLabelText("Backup email (primary)");
       await user.type(input, "backup@example.com");
@@ -166,7 +169,6 @@ describe("AccountPage", () => {
     });
 
     it("updates the secondary backup email field on input", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const input = screen.getByLabelText("Backup email (secondary)");
       await user.type(input, "alt@example.com");
@@ -174,13 +176,16 @@ describe("AccountPage", () => {
     });
 
     it("preserves all field values when updating multiple fields (merge behavior)", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
 
-      await user.type(screen.getByLabelText("Phone number"), "555-1234");
-      await user.type(screen.getByLabelText("Mailing address"), "123 Main St");
-      await user.type(screen.getByLabelText("Backup email (primary)"), "backup@example.com");
-      await user.type(screen.getByLabelText("Backup email (secondary)"), "alt@example.com");
+      await user.click(screen.getByLabelText("Phone number"));
+      await user.paste("555-1234");
+      await user.click(screen.getByLabelText("Mailing address"));
+      await user.paste("123 Main St");
+      await user.click(screen.getByLabelText("Backup email (primary)"));
+      await user.paste("backup@example.com");
+      await user.click(screen.getByLabelText("Backup email (secondary)"));
+      await user.paste("alt@example.com");
 
       expect(screen.getByLabelText("Phone number")).toHaveValue("555-1234");
       expect(screen.getByLabelText("Mailing address")).toHaveValue("123 Main St");
@@ -189,14 +194,12 @@ describe("AccountPage", () => {
     });
 
     it('shows "Saved locally" feedback after form submission', async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
       expect(screen.getByText("Saved locally — sync options coming soon.")).toBeInTheDocument();
     });
 
     it("clears the saved feedback when a field is changed after submission", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
 
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
@@ -216,7 +219,6 @@ describe("AccountPage", () => {
     });
 
     it("form submit does not navigate away (default prevented)", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const form = screen.getByRole("button", { name: "Save contact info" }).closest("form");
       const submitSpy = vi.fn((e) => e.preventDefault());
@@ -227,7 +229,6 @@ describe("AccountPage", () => {
     });
 
     it("calls preventDefault on form submit event", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
       const form = screen.getByRole("button", { name: "Save contact info" }).closest("form");
       let submittedEvent;
@@ -242,10 +243,10 @@ describe("AccountPage", () => {
     });
 
     it("submits with prefilled data and shows feedback", async () => {
-      const user = userEvent.setup();
       renderAccountPage();
 
-      await user.type(screen.getByLabelText("Phone number"), "555-9999");
+      await user.click(screen.getByLabelText("Phone number"));
+      await user.paste("555-9999");
       await user.click(screen.getByRole("button", { name: "Save contact info" }));
 
       expect(screen.getByText("Saved locally — sync options coming soon.")).toBeInTheDocument();

--- a/frontend/src/pages/Auth/Login.test.jsx
+++ b/frontend/src/pages/Auth/Login.test.jsx
@@ -29,9 +29,12 @@ function renderLogin() {
 }
 
 describe("Login (unit)", () => {
+  let user;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockError = null;
+    user = userEvent.setup({ delay: null });
   });
 
   it("renders sign in form", () => {
@@ -45,9 +48,11 @@ describe("Login (unit)", () => {
   it("calls login on submit with email and password", async () => {
     mockLogin.mockResolvedValue(undefined);
     renderLogin();
-    await userEvent.type(screen.getByLabelText(/Email/i), "test@example.com");
-    await userEvent.type(screen.getByLabelText(/Password/i), "password123");
-    await userEvent.click(screen.getByRole("button", { name: "Sign In" }));
+    await user.click(screen.getByLabelText(/Email/i));
+    await user.paste("test@example.com");
+    await user.click(screen.getByLabelText(/Password/i));
+    await user.paste("password123");
+    await user.click(screen.getByRole("button", { name: "Sign In" }));
     expect(mockLogin).toHaveBeenCalledWith("test@example.com", "password123");
   });
 

--- a/frontend/src/pages/Auth/Register.test.jsx
+++ b/frontend/src/pages/Auth/Register.test.jsx
@@ -20,9 +20,12 @@ vi.mock("../../components/Auth/SocialLoginButtons", () => ({
 }));
 
 describe("Register (unit)", () => {
+  let user;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockError = null;
+    user = userEvent.setup({ delay: null });
   });
 
   it("renders registration form", () => {
@@ -45,10 +48,13 @@ describe("Register (unit)", () => {
         <Register />
       </TestMemoryRouter>,
     );
-    await userEvent.type(screen.getByLabelText(/Display Name/i), "Test User");
-    await userEvent.type(screen.getByLabelText(/Email/i), "new@example.com");
-    await userEvent.type(screen.getByLabelText(/Password/i), "secret123");
-    await userEvent.click(screen.getByRole("button", { name: "Sign Up" }));
+    await user.click(screen.getByLabelText(/Display Name/i));
+    await user.paste("Test User");
+    await user.click(screen.getByLabelText(/Email/i));
+    await user.paste("new@example.com");
+    await user.click(screen.getByLabelText(/Password/i));
+    await user.paste("secret123");
+    await user.click(screen.getByRole("button", { name: "Sign Up" }));
     expect(mockRegister).toHaveBeenCalledWith("new@example.com", "secret123", {
       displayName: "Test User",
     });

--- a/frontend/src/pages/Collectibles/components/CollectiblesToolbar.test.jsx
+++ b/frontend/src/pages/Collectibles/components/CollectiblesToolbar.test.jsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { sortOptions } from "../constants.js";
@@ -245,20 +245,20 @@ describe("CollectiblesToolbar", () => {
       expect(props.onSortFieldChange).toHaveBeenCalledWith("story");
     });
 
-    it("calls onSortFieldChange for each sort option from constants", async () => {
-      const user = userEvent.setup();
-      for (let i = 0; i < sortOptions.length; i++) {
-        cleanup();
-        const option = sortOptions[i];
-        const prevOption = sortOptions[(i + 1) % sortOptions.length];
-        const onSortFieldChange = vi.fn();
-        renderToolbar({
-          onSortFieldChange,
-          sortField: prevOption.value,
-        });
-        await user.selectOptions(screen.getByLabelText("Sort by"), option.value);
-        expect(onSortFieldChange).toHaveBeenCalledWith(option.value);
-      }
+    it.each(
+      sortOptions.map((option, i) => ({
+        value: option.value,
+        prevValue: sortOptions[(i + 1) % sortOptions.length].value,
+      })),
+    )("calls onSortFieldChange when selecting $value", ({ value, prevValue }) => {
+      const onSortFieldChange = vi.fn();
+      renderToolbar({
+        onSortFieldChange,
+        sortField: prevValue,
+      });
+      const select = screen.getByLabelText("Sort by");
+      fireEvent.change(select, { target: { value } });
+      expect(onSortFieldChange).toHaveBeenCalledWith(value);
     });
 
     it("sort direction button has sort-direction class", () => {

--- a/frontend/src/pages/Collectibles/index.test.jsx
+++ b/frontend/src/pages/Collectibles/index.test.jsx
@@ -1,10 +1,25 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
-import { AuthProvider } from "../../contexts/AuthContext";
-import { AuthModalProvider } from "../../contexts/AuthModalContext";
 import { TestMemoryRouter } from "../../test/router.jsx";
 import CollectiblesPage from "./index.jsx";
+
+const mockOpenAuthModal = vi.hoisted(() => vi.fn());
+
+vi.mock("../../contexts/AuthContext", () => ({
+  AuthProvider: ({ children }) => children,
+  useAuth: () => ({ user: null, loading: false }),
+}));
+
+vi.mock("../../contexts/AuthModalContext", () => ({
+  AuthModalProvider: ({ children }) => children,
+  useAuthModal: () => ({
+    isOpen: false,
+    openAuthModal: mockOpenAuthModal,
+    closeAuthModal: vi.fn(),
+    context: null,
+  }),
+}));
 
 const { testCollectibles, testDatasetMeta, testDatasetStories } = vi.hoisted(() => {
   const collectibles = [
@@ -67,13 +82,7 @@ vi.mock("../../data/collectibles", () => ({
 }));
 
 function renderWithRouter(ui) {
-  return render(
-    <AuthProvider>
-      <AuthModalProvider>
-        <TestMemoryRouter>{ui}</TestMemoryRouter>
-      </AuthModalProvider>
-    </AuthProvider>,
-  );
+  return render(<TestMemoryRouter>{ui}</TestMemoryRouter>);
 }
 
 function setupUser() {


### PR DESCRIPTION
## Summary
Optimizes the 10 slowest Vitest tests to reduce total run time by ~65% (from ~2s aggregate to ~720ms) for these tests.

## Changes
- **Account**: `userEvent.paste()` + shared `user` with `delay: null` for bulk form input
- **Register/Login**: paste + `delay: null` for submit tests
- **AuthModal**: shared user setup, paste for multi-field flows
- **Collectibles**: lightweight AuthContext/AuthModalContext mocks instead of full providers
- **App**: mock `lib/firebase` (auth: null) so AuthProvider skips Firebase init
- **CollectiblesToolbar**: parameterize sort-option test with `it.each` + `fireEvent.change`

Preserves behavior and coverage.

Made with [Cursor](https://cursor.com)