### PR TITLE
Production deploy: Firebase Hosting and GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -1,0 +1,52 @@
+name: Deploy Firebase
+
+# Production deploy: run manually after configuring repository secrets (see AGENTS.md).
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: firebase-deploy-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build frontend and deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_JSON }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Production build (Vite)
+        working-directory: frontend
+        run: npm run build
+        env:
+          VITE_USE_EMULATORS: "false"
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
+          VITE_FIREBASE_MEASUREMENT_ID: ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }}
+
+      - name: Install Cloud Functions dependencies
+        working-directory: functions
+        run: npm ci
+
+      - name: Deploy Hosting, Firestore, and Functions
+        run: npx --yes firebase-tools@15 deploy --only hosting,firestore,functions --project storydeck-16 --non-interactive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Lost Tales Marketplace is a single-product Vite + React 18 SPA (`frontend/`) bac
 |------|------|
 | `frontend/` | Vite + React app; run dev server and frontend tests here |
 | `functions/` | Cloud Functions (`firebase-functions` + `firebase-admin`); emulator loads this code |
-| `firebase.json`, `.firebaserc` | Emulator ports, Firestore rules path, default Firebase project (`storydeck-16`) |
+| `firebase.json`, `.firebaserc` | Hosting (`frontend/dist`), emulators, Firestore, Functions; default project `storydeck-16` |
 | `firestore.rules`, `firestore.indexes.json` | Firestore security rules and composite indexes |
 
 ### Setup
@@ -63,6 +63,34 @@ The frontend `.env` must have `VITE_USE_EMULATORS=true` and dummy `VITE_FIREBASE
 - **Cloud Functions tests**: `cd functions && npm test` — Node’s built-in test runner (`*.test.js` next to source).
 - **End-to-end tests**: Playwright (`cd frontend && npm run test:e2e`). Locally the config builds then previews the production bundle on port 4173. In CI, the workflow builds once and sets `PLAYWRIGHT_SKIP_BUILD=1` so Playwright only runs preview. Specs live under `frontend/e2e/`.
 - **Build**: `cd frontend && npm run build` — runs `vite build`.
+- **Production deploy (local CLI)**: `npm run deploy:firebase` from the repo root after `frontend/.env` is filled with production `VITE_FIREBASE_*` and `VITE_USE_EMULATORS=false`, and you are logged in (`firebase login` or `GOOGLE_APPLICATION_CREDENTIALS`).
+
+### Production deployment
+
+1. **Firebase console (one-time per project)**  
+   - Enable **Authentication** providers you ship (see `frontend/README.md`).  
+   - Under Auth → Settings, add your **Hosting domain** (and any custom domain) to **Authorized domains**.  
+   - Open **Hosting** in the console and complete the “Get started” flow if you have not deployed Hosting before.
+
+2. **GitHub Actions (optional automation)**  
+   Workflow: `.github/workflows/deploy-firebase.yml` (manual **Run workflow** only). Configure these **repository secrets**:
+
+   | Secret | Purpose |
+   |--------|---------|
+   | `FIREBASE_SERVICE_ACCOUNT_JSON` | Full JSON for a service account that can deploy Hosting, Firestore rules/indexes, and Cloud Functions (Firebase recommends a dedicated CI account with the right IAM roles). |
+   | `VITE_FIREBASE_API_KEY` | Same values as `frontend/.env.example` — injected at **build** time for the production bundle. |
+   | `VITE_FIREBASE_AUTH_DOMAIN` | |
+   | `VITE_FIREBASE_PROJECT_ID` | |
+   | `VITE_FIREBASE_STORAGE_BUCKET` | |
+   | `VITE_FIREBASE_MESSAGING_SENDER_ID` | |
+   | `VITE_FIREBASE_APP_ID` | |
+   | `VITE_FIREBASE_MEASUREMENT_ID` | |
+
+3. **What gets deployed**  
+   `firebase deploy --only hosting,firestore,functions` publishes the Vite build from `frontend/dist`, Firestore rules/indexes, and Cloud Functions. It does not deploy other Google Cloud resources.
+
+4. **After deploy**  
+   Consider **App Check**, error/monitoring dashboards, and Firestore **backup** policy for your risk tolerance.
 
 ### Gotchas
 

--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,36 @@
   "functions": {
     "source": "functions"
   },
+  "hosting": {
+    "public": "frontend/dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "headers": [
+      {
+        "source": "/assets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      }
+    ]
+  },
   "emulators": {
     "firestore": {
       "port": 8080

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "check": "biome check --write .",
     "ci": "biome ci .",
     "test": "npm run test --prefix frontend",
+    "deploy:firebase": "npm run build --prefix frontend && npx --yes firebase-tools@15 deploy --only hosting,firestore,functions --project storydeck-16 --non-interactive",
     "prepare": "husky"
   },
   "devDependencies": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change wires the Vite app to **Firebase Hosting** and adds a **manual** GitHub Actions workflow to build the frontend with production Firebase env vars and deploy **Hosting, Firestore (rules + indexes), and Cloud Functions** to `storydeck-16`.

## Changes

- **`firebase.json`**: Hosting target `frontend/dist`, SPA fallback rewrite to `index.html`, long-lived cache for hashed `/assets/**`, `no-cache` for `index.html`.
- **`.github/workflows/deploy-firebase.yml`**: `workflow_dispatch` job using `google-github-actions/auth` and `FIREBASE_SERVICE_ACCOUNT_JSON`, plus the same `VITE_FIREBASE_*` secrets as local `.env`.
- **`package.json`**: `npm run deploy:firebase` for authenticated local deploys after a production `frontend/.env` is configured.
- **`AGENTS.md`**: Console checklist (Auth providers, authorized domains, Hosting onboarding), secret names table, and post-deploy reminders (App Check, monitoring, backups).

## What you need to do in GitHub / Firebase

1. In the Firebase console: complete Hosting setup if needed; configure Auth providers and **authorized domains** for your live URL.
2. Add repository secrets listed in `AGENTS.md` (service account JSON + all `VITE_FIREBASE_*` values).
3. Run **Actions → Deploy Firebase → Run workflow**.

## Testing

- `npm run check` (root)
- `cd frontend && npm run test -- --run`
- `cd functions && npm test`
- `cd frontend && npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cb53ba04-f7cd-4c05-aaef-17fa8a07b7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb53ba04-f7cd-4c05-aaef-17fa8a07b7b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

