### PR TITLE
Collectibles page: mobile responsiveness

### DIFF
--- a/frontend/src/pages/Collectibles/Collectibles.css
+++ b/frontend/src/pages/Collectibles/Collectibles.css
@@ -1,8 +1,10 @@
 .cards-page {
-  padding: 2.5rem clamp(1.5rem, 4vw, 3rem);
+  padding: 2.5rem clamp(1rem, 4vw, 3rem);
   max-width: 1200px;
   margin: 0 auto 4rem;
   color: #f4f1ff;
+  min-width: 0;
+  box-sizing: border-box;
 }
 
 .cards-header {
@@ -26,6 +28,12 @@
   max-width: 48rem;
   color: #cfc6ff;
   line-height: 1.6;
+}
+
+.cards-header h1 {
+  font-size: clamp(1.65rem, 4vw + 0.5rem, 2.25rem);
+  line-height: 1.15;
+  margin: 0.15rem 0 0;
 }
 
 .view-toggle {
@@ -142,6 +150,13 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  min-width: 0;
+}
+
+.filter-control .sort-wrapper select {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
 }
 
 .sort-direction {
@@ -199,7 +214,10 @@
   background: rgba(18, 12, 33, 0.95);
   border-radius: 20px;
   border: 1px solid rgba(121, 97, 208, 0.45);
-  overflow: hidden;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior-x: contain;
   box-shadow: 0 25px 45px rgba(0, 0, 0, 0.4);
 }
 
@@ -310,8 +328,9 @@
 .cards-grid {
   margin-top: 2.5rem;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 260px), 1fr));
   gap: 1.75rem;
+  min-width: 0;
 }
 
 .card-tile {
@@ -344,7 +363,16 @@
 .card-tile header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.75rem;
+}
+
+.card-tile h2 {
+  font-size: clamp(1.05rem, 2.5vw + 0.65rem, 1.35rem);
+  line-height: 1.25;
+  margin: 0;
+  overflow-wrap: anywhere;
 }
 
 .card-id {
@@ -399,10 +427,44 @@
 @media (max-width: 720px) {
   .cards-header {
     flex-direction: column;
+    align-items: stretch;
+    gap: 1.25rem;
+  }
+
+  .view-toggle {
+    display: flex;
+    width: 100%;
+    max-width: 100%;
+    align-self: stretch;
+  }
+
+  .view-toggle button {
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 2.75rem;
+    padding: 0.65rem 0.65rem;
   }
 
   .card-stats {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .cards-table th,
+  .cards-table td {
+    padding: 0.75rem 0.85rem;
+    font-size: 0.875rem;
+  }
+
+  .cards-page {
+    margin-bottom: 2.5rem;
+  }
+
+  .add-to-collection--table {
+    min-width: 0;
+  }
+
+  .add-to-collection__button {
+    min-height: 2.75rem;
   }
 }
 
@@ -413,6 +475,35 @@
 
   .cards-toolbar {
     padding: 1.25rem;
+  }
+
+  .filter-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .toolbar-footer {
+    flex-direction: column;
+    align-items: stretch;
+    text-align: center;
+  }
+
+  .toolbar-footer .reset-button {
+    align-self: center;
+    min-height: 2.75rem;
+    padding: 0.65rem 1.5rem;
+  }
+
+  .cards-grid {
+    grid-template-columns: 1fr;
+    gap: 1.25rem;
+  }
+
+  .card-tile {
+    padding: 1.35rem;
+  }
+
+  .cards-page {
+    padding-top: 1.5rem;
   }
 }
 
@@ -485,10 +576,4 @@
 .add-to-collection__feedback--details {
   font-size: 0.65rem;
   opacity: 0.75;
-}
-
-@media (max-width: 720px) {
-  .add-to-collection--table {
-    min-width: 0;
-  }
 }

--- a/frontend/src/pages/Collectibles/components/CollectibleTable.jsx
+++ b/frontend/src/pages/Collectibles/components/CollectibleTable.jsx
@@ -16,7 +16,7 @@ export default function CollectibleTable({ collectibles }) {
   };
 
   return (
-    <div className="cards-table-wrapper">
+    <section className="cards-table-wrapper" aria-label="Collectibles table">
       <table className="cards-table">
         <thead>
           <tr>
@@ -65,6 +65,6 @@ export default function CollectibleTable({ collectibles }) {
           ))}
         </tbody>
       </table>
-    </div>
+    </section>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves the `/collectibles` experience on small viewports without changing behavior or data flow.

## Changes

- **Table view**: The table keeps its `min-width` for readability, but the wrapper now scrolls horizontally with touch-friendly momentum (`-webkit-overflow-scrolling: touch`) instead of clipping on narrow screens.
- **Header**: Fluid `h1` sizing; grid/table toggle stretches full width with larger tap targets from 720px down.
- **Toolbar**: Sort row uses a flexible select next to the direction button; filters stack in a single column below 520px; result count and reset stack cleanly on small screens.
- **Grid tiles**: Safer grid column sizing (`min(100%, 260px)`), wrapping tile header, clamped title size with `overflow-wrap`, slightly tighter tile padding on narrow breakpoints.

## Testing

- `npm run check` (repo root)
- `cd frontend && npm run test -- --run src/pages/Collectibles`

## Notes

The table wrapper is a `<section aria-label="Collectibles table">` for semantics and screen readers (Biome-friendly; no non-interactive `tabIndex`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67d60438-c6ec-46fe-b18c-82501dacf8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67d60438-c6ec-46fe-b18c-82501dacf8d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

