### PR TITLE
Responsive collapsible header navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Link, Route, Routes } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { BrowserRouter, Link, Route, Routes, useLocation } from "react-router-dom";
 import { PostHogPageviews } from "./analytics/PostHogPageviews.jsx";
 import { useAuth } from "./contexts/AuthContext";
 import { useAuthModal } from "./contexts/AuthModalContext.jsx";
@@ -14,9 +15,29 @@ import MarketPage from "./pages/Market";
 import NotFound from "./pages/NotFound";
 import { ROUTER_FUTURE_FLAGS } from "./routerFuture.js";
 
-function App() {
+function MainNav() {
   const { user, logout, loading } = useAuth();
   const { openAuthModal } = useAuthModal();
+  const location = useLocation();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset menu when the route changes (body only calls stable setState)
+  useEffect(() => {
+    setMenuOpen(false);
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!menuOpen) {
+      return;
+    }
+    const onKeyDown = (e) => {
+      if (e.key === "Escape") {
+        setMenuOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [menuOpen]);
 
   const handleSignOut = async () => {
     try {
@@ -26,10 +47,25 @@ function App() {
     }
   };
 
+  const panelClassName = menuOpen ? "main-nav__panel main-nav__panel--open" : "main-nav__panel";
+
   return (
-    <BrowserRouter future={ROUTER_FUTURE_FLAGS}>
-      <PostHogPageviews />
-      <nav className="main-nav">
+    <nav className="main-nav" aria-label="Primary">
+      <button
+        type="button"
+        className="main-nav__menu-toggle"
+        aria-expanded={menuOpen}
+        aria-controls="main-nav-panel"
+        onClick={() => setMenuOpen((open) => !open)}
+      >
+        <span className="main-nav__menu-toggle-bars" aria-hidden="true">
+          <span className="main-nav__menu-toggle-bar" />
+          <span className="main-nav__menu-toggle-bar" />
+          <span className="main-nav__menu-toggle-bar" />
+        </span>
+        <span className="main-nav__menu-toggle-label">{menuOpen ? "Close" : "Menu"}</span>
+      </button>
+      <div className={panelClassName} id="main-nav-panel">
         <div className="main-nav__links">
           <Link to="/">Home</Link>
           <Link to="/collectibles">Collectibles</Link>
@@ -56,7 +92,16 @@ function App() {
             </>
           )}
         </div>
-      </nav>
+      </div>
+    </nav>
+  );
+}
+
+function App() {
+  return (
+    <BrowserRouter future={ROUTER_FUTURE_FLAGS}>
+      <PostHogPageviews />
+      <MainNav />
       <hr />
       <Routes>
         <Route path="/" element={<Home />} />

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -15,7 +15,57 @@ body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.main-nav__menu-toggle {
+  display: none;
+  flex-shrink: 0;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid rgba(138, 43, 226, 0.6);
+  background: rgba(13, 10, 26, 0.5);
+  color: #e0e0e0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+
+.main-nav__menu-toggle:hover {
+  background: rgba(138, 43, 226, 0.2);
+  color: #ffffff;
+}
+
+.main-nav__menu-toggle-bars {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 4px;
+  width: 1.25rem;
+}
+
+.main-nav__menu-toggle-bar {
+  display: block;
+  height: 2px;
+  width: 100%;
+  border-radius: 1px;
+  background: currentcolor;
+}
+
+.main-nav__panel {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
   flex-wrap: wrap;
+  gap: 1rem;
+  min-width: 0;
 }
 
 .main-nav__links,
@@ -23,6 +73,7 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+  min-width: 0;
 }
 
 .main-nav a,
@@ -51,6 +102,58 @@ body {
 
 .main-nav__welcome {
   padding: 0.5rem 0;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 768px) {
+  .main-nav {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .main-nav__menu-toggle {
+    display: inline-flex;
+    align-self: flex-end;
+  }
+
+  .main-nav__panel {
+    display: none;
+    flex: none;
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    gap: 1.25rem;
+    padding-top: 0.25rem;
+  }
+
+  .main-nav__panel--open {
+    display: flex;
+  }
+
+  .main-nav__links,
+  .main-nav__auth {
+    flex-direction: column;
+    align-items: stretch;
+    width: 100%;
+    gap: 0.5rem;
+  }
+
+  .main-nav a,
+  .main-nav button {
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    text-align: center;
+  }
+
+  .main-nav__welcome {
+    text-align: center;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+  }
 }
 
 .auth-page {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- On viewports **768px and below**, the primary nav shows a **Menu** control (hamburger + label) and hides links and auth until opened, so the bar no longer forces horizontal scrolling.
- The expanded panel is a **full-width column**: nav links and auth actions stack with **centered, full-width** controls; long welcome text uses **overflow-wrap** so emails do not overflow.
- **Desktop** behavior stays a single row with **flex-wrap** so tight widths still wrap instead of clipping.
- The menu **closes on navigation** (route change), **Escape**, and toggles with **aria-expanded** / **aria-controls** for accessibility.

## Testing

- `npm run check` (repo root)
- `cd frontend && npm run test -- --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7098d92-bb7b-4262-b509-d1d08479e11f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7098d92-bb7b-4262-b509-d1d08479e11f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

