### PR TITLE
feat(game): conveyor belt standard vs express push distances

### DIFF
--- a/frontend/src/game/conveyor.js
+++ b/frontend/src/game/conveyor.js
@@ -1,0 +1,72 @@
+/**
+ * Conveyor belt movement for a square grid board.
+ * Standard belts push a robot one tile in the belt direction; express belts push two tiles.
+ * Pushes stop at the board edge (partial movement is allowed).
+ */
+
+/** @typedef {'north' | 'east' | 'south' | 'west'} ConveyorDirection */
+/** @typedef {'standard' | 'express'} ConveyorKind */
+
+/** @typedef {{ x: number; y: number }} GridPosition */
+/** @typedef {{ width: number; height: number }} BoardSize */
+/** @typedef {{ kind: ConveyorKind; direction: ConveyorDirection }} ConveyorBelt */
+
+export const CONVEYOR_STANDARD = "standard";
+export const CONVEYOR_EXPRESS = "express";
+
+const DELTA = /** @type {Record<ConveyorDirection, { dx: number; dy: number }>} */ ({
+  north: { dx: 0, dy: -1 },
+  east: { dx: 1, dy: 0 },
+  south: { dx: 0, dy: 1 },
+  west: { dx: -1, dy: 0 },
+});
+
+/**
+ * Number of grid steps the belt moves the robot during the conveyor register phase.
+ * @param {ConveyorKind} kind
+ * @returns {number}
+ */
+export function conveyorStepCount(kind) {
+  return kind === CONVEYOR_EXPRESS ? 2 : 1;
+}
+
+/**
+ * @param {number} x
+ * @param {number} y
+ * @param {BoardSize} boardSize
+ * @returns {boolean}
+ */
+function isInsideBoard(x, y, boardSize) {
+  return x >= 0 && y >= 0 && x < boardSize.width && y < boardSize.height;
+}
+
+/**
+ * New position after the belt push. The robot is assumed to be standing on the belt tile
+ * before this runs (same as classic register-phase resolution).
+ *
+ * @param {GridPosition} position
+ * @param {ConveyorBelt} belt
+ * @param {BoardSize} boardSize
+ * @returns {GridPosition}
+ */
+export function applyConveyorPush(position, belt, boardSize) {
+  const delta = DELTA[belt.direction];
+  if (!delta) {
+    return { ...position };
+  }
+
+  const steps = conveyorStepCount(belt.kind);
+  let { x, y } = position;
+
+  for (let i = 0; i < steps; i++) {
+    const nextX = x + delta.dx;
+    const nextY = y + delta.dy;
+    if (!isInsideBoard(nextX, nextY, boardSize)) {
+      break;
+    }
+    x = nextX;
+    y = nextY;
+  }
+
+  return { x, y };
+}

--- a/frontend/src/game/conveyor.test.js
+++ b/frontend/src/game/conveyor.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyConveyorPush,
+  CONVEYOR_EXPRESS,
+  CONVEYOR_STANDARD,
+  conveyorStepCount,
+} from "./conveyor.js";
+
+const board10 = { width: 10, height: 10 };
+
+describe("conveyorStepCount", () => {
+  it("returns 1 for standard belts", () => {
+    expect(conveyorStepCount(CONVEYOR_STANDARD)).toBe(1);
+  });
+
+  it("returns 2 for express belts", () => {
+    expect(conveyorStepCount(CONVEYOR_EXPRESS)).toBe(2);
+  });
+});
+
+describe("applyConveyorPush", () => {
+  it("moves one tile east on a standard belt", () => {
+    expect(
+      applyConveyorPush({ x: 3, y: 4 }, { kind: CONVEYOR_STANDARD, direction: "east" }, board10),
+    ).toEqual({ x: 4, y: 4 });
+  });
+
+  it("moves two tiles east on an express belt", () => {
+    expect(
+      applyConveyorPush({ x: 3, y: 4 }, { kind: CONVEYOR_EXPRESS, direction: "east" }, board10),
+    ).toEqual({ x: 5, y: 4 });
+  });
+
+  it("moves one tile north on a standard belt", () => {
+    expect(
+      applyConveyorPush({ x: 2, y: 2 }, { kind: CONVEYOR_STANDARD, direction: "north" }, board10),
+    ).toEqual({ x: 2, y: 1 });
+  });
+
+  it("stops at the board edge on standard (cannot leave)", () => {
+    expect(
+      applyConveyorPush({ x: 9, y: 5 }, { kind: CONVEYOR_STANDARD, direction: "east" }, board10),
+    ).toEqual({ x: 9, y: 5 });
+  });
+
+  it("allows partial express movement when only one step fits", () => {
+    expect(
+      applyConveyorPush({ x: 8, y: 5 }, { kind: CONVEYOR_EXPRESS, direction: "east" }, board10),
+    ).toEqual({ x: 9, y: 5 });
+  });
+
+  it("returns the same position when direction is unknown", () => {
+    const belt = { kind: CONVEYOR_STANDARD, direction: "up" };
+    expect(applyConveyorPush({ x: 1, y: 1 }, belt, board10)).toEqual({ x: 1, y: 1 });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a small pure module for grid-based conveyor movement during a register-style phase:

- **Standard** belts move the robot **1** tile in the belt direction.
- **Express** belts move the robot **2** tiles in the same direction.
- Movement **stops at the board edge**; express can complete a single step if the second would leave the grid.

## Files

- `frontend/src/game/conveyor.js` — `conveyorStepCount`, `applyConveyorPush`, kind constants
- `frontend/src/game/conveyor.test.js` — Vitest coverage for directions, both kinds, and edge cases

## Notes

There was no existing board/robot UI in the repo; this is the domain layer you can call from tile resolution once the board model exists. If you need chained belts (second tile’s belt direction) or push priorities, we can extend `applyConveyorPush` or add a separate register-phase orchestrator.

## Testing

- `cd frontend && npm test -- --run src/game/conveyor.test.js`
- `npm run check` (repo root) after `npm install`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ac08f59-784d-455b-b2ed-674981625c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ac08f59-784d-455b-b2ed-674981625c07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

