### PR TITLE
fix(frontend): polish 404 Not Found page

### DIFF
--- a/frontend/src/pages/NotFound/NotFound.css
+++ b/frontend/src/pages/NotFound/NotFound.css
@@ -1,0 +1,37 @@
+.not-found-page {
+  max-width: 32rem;
+  margin: 3rem auto;
+  padding: 2.5rem 2rem;
+  background: rgba(24, 18, 45, 0.9);
+  border-radius: 16px;
+  border: 1px solid rgba(138, 43, 226, 0.25);
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.45);
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.not-found-page h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  color: #ffffff;
+}
+
+.not-found-page p {
+  margin: 0;
+  color: rgba(224, 224, 224, 0.85);
+  line-height: 1.6;
+}
+
+.not-found-page__link {
+  align-self: center;
+  margin-top: 0.5rem;
+  color: #cfa8ff;
+  font-weight: 600;
+  text-decoration: underline;
+}
+
+.not-found-page__link:hover {
+  color: #ffffff;
+}

--- a/frontend/src/pages/NotFound/NotFound.test.jsx
+++ b/frontend/src/pages/NotFound/NotFound.test.jsx
@@ -15,4 +15,16 @@ describe("NotFound (integration)", () => {
     );
     expect(screen.getByRole("heading", { name: /page not found/i })).toBeInTheDocument();
   });
+
+  it("links back to the home page", () => {
+    render(
+      <TestMemoryRouter initialEntries={["/this-route-does-not-exist"]}>
+        <Routes>
+          <Route path="*" element={<NotFound />} />
+        </Routes>
+      </TestMemoryRouter>,
+    );
+    const homeLink = screen.getByRole("link", { name: /back to home/i });
+    expect(homeLink).toHaveAttribute("href", "/");
+  });
 });

--- a/frontend/src/pages/NotFound/index.jsx
+++ b/frontend/src/pages/NotFound/index.jsx
@@ -1,3 +1,14 @@
+import { Link } from "react-router-dom";
+import "./NotFound.css";
+
 export default function NotFound() {
-  return <h2>Page not found</h2>;
+  return (
+    <section className="not-found-page">
+      <h1>Page not found</h1>
+      <p>We could not find that page. It may have moved, or the link might be out of date.</p>
+      <Link className="not-found-page__link" to="/">
+        Back to Home
+      </Link>
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- Replace bare "Page not found" heading with a styled section, short explanation, and **Back to Home** link to `/`.
- Add `NotFound.css` matching the app’s dark card aesthetic.
- Extend integration tests to assert the home link.

## Test plan
- [x] `cd frontend && npm run test -- src/pages/NotFound/NotFound.test.jsx`
- [x] Browse `http://127.0.0.1:5173/this-route-does-not-exist` — heading, copy, link present
- [x] `npm run build`


Made with [Cursor](https://cursor.com)