### PR TITLE
fix(firestore): allow trades list reads via participants

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -52,8 +52,13 @@ service cloud.firestore {
     }
 
     // Trades are created by a callable Cloud Function so clients cannot spoof them.
+    // List queries use participants array-contains; rule must match that constraint.
     match /trades/{tradeId} {
-      allow read: if signedIn() && (request.auth.uid == resource.data.buyerUid || request.auth.uid == resource.data.sellerUid);
+      allow read: if signedIn() && (
+        request.auth.uid in resource.data.participants
+        || request.auth.uid == resource.data.buyerUid
+        || request.auth.uid == resource.data.sellerUid
+      );
       allow create, update, delete: if false;
     }
 


### PR DESCRIPTION
## Summary
- Align `/trades` read rules with client queries that use `where("participants", "array-contains", uid)`.
- Keep backward-compatible `buyerUid` / `sellerUid` checks for older documents.

## Root cause
List queries evaluate security rules per returned document. Trades created by the callable include a `participants` array, but reads only matched `buyerUid`/`sellerUid`, causing permission-denied failures on the Account trades panel.

## Test plan
- [x] Account page (emulator): trades section loads without permission error; empty state shows "No trades yet" only
- [x] `cd frontend && npm run test -- src/pages/Account/hooks/useMyTrades.test.js src/pages/Account/components/TradesPanel.test.jsx`
- [ ] After deploy: restart emulators and run `functions/scripts/test-trades-query.mjs` (local only) to confirm `QUERY_OK`


Made with [Cursor](https://cursor.com)